### PR TITLE
WolfDiviner bug fix

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -2464,6 +2464,7 @@ class Psychic extends Player
     
     # 処刑で死んだ人を調べる
     beforebury:(game,type)->
+        @setFlag if @flag? then @flag else ""
         game.players.filter((x)->x.dead && x.found=="punish").forEach (x)=>
             @setFlag @flag+"#{@name}の霊能の結果、前日処刑された#{x.name}は#{x.psychicResult}でした。\n"
 


### PR DESCRIPTION
Psychic created by WolfDiviner show first psychic result as “null#{@name}の霊能の結果、前日処刑された#{x.name}は#{x.psychicResult}でした。\n”, because @flag is null at that point.