### PR TITLE
Pyrotechnist bug fix

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -1144,7 +1144,7 @@ class Game
                 # 死んだ
                 t.die this,"werewolf",target.from
             # 逃亡者を探す
-            runners=@players.filter (x)=>!x.dead && x.isJobType("Fugitive") && x.target==target.to
+            runners=@players.filter (x)=>!x.dead && x.isJobType("Fugitive") && x.accessByJobType("Fugitive")?.target==target.to
             runners.forEach (x)=>
                 x.die this,"werewolf2",target.from   # その家に逃げていたら逃亡者も死ぬ
 
@@ -3912,7 +3912,7 @@ class Vampire extends Player
         return if t.dead
         t.die game,"vampire",@id
         # 逃亡者を探す
-        runners=game.players.filter (x)=>!x.dead && x.isJobType("Fugitive") && x.target==t.id
+        runners=game.players.filter (x)=>!x.dead && x.isJobType("Fugitive") && x.accessByJobType("Fugitive")?.target==t.id
         runners.forEach (x)=>
             x.die game,"vampire2",@id   # その家に逃げていたら逃亡者も死ぬ
     makejobinfo:(game,result)->


### PR DESCRIPTION
1. Fireworks should be lit at just the moment before sunset, instead of immediately.
2. Dead players like BloodyMary also need ```@uncomplex()``` from WatchingFireworks.