### PR TITLE
Conflict fix

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -962,7 +962,10 @@ class Game
                     newpl=Player.factory null,pl,null,WatchingFireworks
                     pl.transProfile newpl
                     newpl.cmplFlag=x[0].id
-                    pl.transform @,newpl,true
+                    pl.transform this,newpl,true
+                # Pyrotechnist should break the blockade of Threatened.sunset
+                for pyr in x
+                    pyr.accessByJobType("Pyrotechnist").sunset this
 
             alives=[]
             deads=[]


### PR DESCRIPTION
Pyrotechnist should break the blockade of Threatened.sunset, as Pyrotechnist's skill is one used during daytime and "Skill used by threatened player this night will be invalidated."(http://jinrou-doc.uhyohyo.net/jobs/ThreateningWolf.html)

Or rarely, if Pyrotechnist lit the fireworks AND got threatened by ThreateningWolf during one same daytime, this will cause conflicts:
1. Pyrotechnist's skill still works at this night (because #31 ), but nobody would get the tip of "The Pyrotechnist lit the fireworks, nobody can use skill tonight." (because ```Threatened.sunset```).
2. Pyrotechnist's skill will be active for two night, because he cannot ```@setFlag "done"``` at the first sunset.