### PR TITLE
BombTrapped & TrapGuarded need a @midnightSort

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -6668,6 +6668,7 @@ class Complex
     isComplex:->true
     getJobname:->@main.getJobname()
     getJobDisp:->@main.getJobDisp()
+    midnightSort: 100
 
     #@mainのやつを呼ぶ
     mcall:(game,method,args...)->


### PR DESCRIPTION
More missing midnightSort in 6adf92f . BombTrapped & TrapGuarded ask @midnightSort and class Complex did not define it, which makes BombTrapped & TrapGuarded working abnormally, TrapGuarded will kill both Guard and Werewolf as ```@midnightSort``` is undefined