### PR TITLE
WolfDiviner bug

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -3038,6 +3038,7 @@ class WolfDiviner extends Werewolf
                 newpl.setFlag null
                 p.transferData newpl
                 p.transform game,newpl,false
+                p=game.getPlayer @flag
                 p.sunset game
                 log=
                     mode:"skill"


### PR DESCRIPTION
didn't refresh ```p```, which may lead to sudden death as ```p.sunset()``` is method of OLD p.