### PR TITLE
TinyFox bug

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -2808,11 +2808,6 @@ class TinyFox extends Diviner
         super
         unless game.rule.divineresult=="immediate"
             @showdivineresult game
-                
-    midnight:(game,midnightSort)->
-        super
-        unless game.rule.divineresult=="immediate"
-            @dodivine game
     dodivine:(game)->
         p=game.getPlayer @target
         if p?

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -2788,26 +2788,6 @@ class TinyFox extends Diviner
         # 子狐は妖狐が分かる
         result.foxes=game.players.filter((x)->x.isFoxVisible()).map (x)->
             x.publicinfo()
-
-    job:(game,playerid)->
-        super
-        pl=game.getPlayer playerid
-        unless pl?
-            return "そのプレイヤーは存在しません。"
-        pl.touched game,@id
-        log=
-            mode:"skill"
-            to:@id
-            comment:"#{@name}が#{pl.name}を占いました。"
-        splashlog game.id,game,log
-        if game.rule.divineresult=="immediate"
-            @dodivine game
-            @showdivineresult game
-        null
-    sunrise:(game)->
-        super
-        unless game.rule.divineresult=="immediate"
-            @showdivineresult game
     dodivine:(game)->
         p=game.getPlayer @target
         if p?


### PR DESCRIPTION
These ```.midnight()```, ```.job()``` and ```.sunrise()``` are not necessary, and the ```super``` in them would make TinyFox always ```@dodivine()``` for twice.
Success rate becomes 75% because of that.
[また、占い能力がありますが、50%の確率で失敗します（結果が得られません）。](http://jinrou-doc.uhyohyo.net/jobs/TinyFox.html)