### PR TITLE
BAN base64 icon

### DIFF
--- a/server/rpc/game/rooms.coffee
+++ b/server/rpc/game/rooms.coffee
@@ -232,6 +232,10 @@ module.exports.actions=(req,res,ss)->
                     return
                 ###
                 
+                # please no, link of data:image/jpeg;base64 would be a disaster
+                if user.icon?.length>512
+                    res error:"Link for Icon is too long.（#{user.icon.length}）"
+                    return
                 if room.blind
                     unless opt?.name
                         res error:"名前を入力して下さい"

--- a/server/rpc/game/rooms.coffee
+++ b/server/rpc/game/rooms.coffee
@@ -233,7 +233,7 @@ module.exports.actions=(req,res,ss)->
                 ###
                 
                 # please no, link of data:image/jpeg;base64 would be a disaster
-                if user.icon?.length>512
+                if user.icon?.length>300
                     res error:"Link for Icon is too long.（#{user.icon.length}）"
                     return
                 if room.blind


### PR DESCRIPTION
This afternoon my server crashed, I'm almost sure that it is related to a player who pasted a 16KB base64 link for icon in blind room. How large could a session be?

```Forever``` tried to restart the server, but it always failed until I manually removed the suspected room from ```Mongo```. 
This is err.log [err_log.txt](https://github.com/uhyo/jinrou/files/824153/err_log.txt)
This is the [base64icon.txt](https://github.com/uhyo/jinrou/files/824174/base64icon.txt)

Yet, I failed to reproduce this crash again after my server back to normal.