### PR TITLE
ThreateningWolf scapegoat sudden dead bug

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -5637,9 +5637,11 @@ class ThreateningWolf extends Werewolf
         null
     sunset:(game)->
         t=game.getPlayer @target
-        return unless t?
-        return if t.dead
-            
+        unless t?
+            return super
+        if t.dead
+            return super
+
         # 威嚇して能力無しにする
         @addGamelog game,"threaten",t.type,@target
         # 複合させる


### PR DESCRIPTION
A ThreateningWolf scapegoat as last wolf will always sudden dead, because the ```super``` at last line of ```ThreateningWolf.sunset()``` is unreachable in such situation.
I roughly checked all the other ```/(?<!->\n\s+)super/```, and did not find more of the same problem.