### PR TITLE
Tweet err handle

### DIFF
--- a/server/oauth.coffee
+++ b/server/oauth.coffee
@@ -17,6 +17,8 @@ class RateLimits
     isSuspended:(type)-> @suspended[type]
     # examine an error response from Twitter.
     examineError: (type, err, raw)->
+        if err.code == "ETIMEDOUT"
+            return
         if @suspended[type]
             # it is already suspended; nothing to do.
             return

--- a/server/oauth.coffee
+++ b/server/oauth.coffee
@@ -17,7 +17,7 @@ class RateLimits
     isSuspended:(type)-> @suspended[type]
     # examine an error response from Twitter.
     examineError: (type, err, raw)->
-        if err.code == "ETIMEDOUT"
+        if err.toString() == "[object Object]"
             return
         if @suspended[type]
             # it is already suspended; nothing to do.


### PR DESCRIPTION
Thanks to GFW, my server is unable to access twitter.
Now my error.log is all like this:
``````
tweet: { Error: connect ECONNREFUSED 31.13.81.17:443
    at Object._errnoException (util.js:7:30)
    at _exceptionWithHostPort (util.js:7:30)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:7:30)

  code: 'ECONNREFUSED',
  errno: 'ECONNREFUSED',
  syscall: 'connect',
  address: '31.13.81.17',
  port: 443 }
TypeError: err.some is not a function
    at RateLimits.examineError (/home/werewolf/jinrou/server/oauth.coffee:24:16)
    at /home/werewolf/jinrou/server/oauth.coffee:55:24
    at Request._callback (/home/werewolf/jinrou/node_modules/twitter/lib/twitter.js:7:30)
    at self.callback (/home/werewolf/jinrou/node_modules/request/request.js:7:30)
    at emitOne (events.js:7:30)
    at Request.emit (events.js:7:30)
    at Request.onRequestError (/home/werewolf/jinrou/node_modules/request/request.js:7:30)
    at emitOne (events.js:7:30)
    at ClientRequest.emit (events.js:7:30)
    at TLSSocket.socketErrorListener (_http_client.js:7:30)
    at emitOne (events.js:7:30)
    at TLSSocket.emit (events.js:7:30)
    at emitErrorNT (internal/streams/destroy.js:7:30)
    at _combinedTickCallback (internal/process/next_tick.js:7:30)
    at process._tickCallback (internal/process/next_tick.js:7:30)
``````
or
``````
tweet: { Error: connect ETIMEDOUT 69.171.244.15:443
    at Object._errnoException (util.js:7:30)
    at _exceptionWithHostPort (util.js:7:30)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:7:30)

  code: 'ETIMEDOUT',
  errno: 'ETIMEDOUT',
  syscall: 'connect',
  address: '69.171.244.15',
  port: 443 }
TypeError: err.some is not a function
    at RateLimits.examineError (/home/werewolf/jinrou/server/oauth.coffee:24:16)
    at /home/werewolf/jinrou/server/oauth.coffee:55:24
    at Request._callback (/home/werewolf/jinrou/node_modules/twitter/lib/twitter.js:7:30)
    at self.callback (/home/werewolf/jinrou/node_modules/request/request.js:7:30)
    at emitOne (events.js:7:30)
    at Request.emit (events.js:7:30)
    at Request.onRequestError (/home/werewolf/jinrou/node_modules/request/request.js:7:30)
    at emitOne (events.js:7:30)
    at ClientRequest.emit (events.js:7:30)
    at TLSSocket.socketErrorListener (_http_client.js:7:30)
    at emitOne (events.js:7:30)
    at TLSSocket.emit (events.js:7:30)
    at emitErrorNT (internal/streams/destroy.js:7:30)
    at _combinedTickCallback (internal/process/next_tick.js:7:30)
    at process._tickCallback (internal/process/next_tick.js:7:30)
``````