### PR TITLE
身代わりセーフティ description update

### DIFF
--- a/client/code/shared/game.coffee
+++ b/client/code/shared/game.coffee
@@ -1352,12 +1352,14 @@ exports.rules=[
                 values:[
                     {
                         value:"full"
-                        label:"身代わりくんは人外、"+SAFETY_EXCLUDED_JOBS.map((job)-> exports.getjobname(job)).join("、")+"になりません"
+                        label:"なし"
                         selected:true
+                        title:"身代わりくんは人外、"+SAFETY_EXCLUDED_JOBS.map((job)-> exports.getjobname(job)).join("、")+"になりません"
                     }
                     {
                         value:"no"
-                        label:"身代わりくんは人外になりません"
+                        label:"あり"
+                        title:"身代わりくんは人外になりません"
                     }
                     {
                         value:"free"

--- a/client/code/shared/game.coffee
+++ b/client/code/shared/game.coffee
@@ -1,5 +1,8 @@
 Shared=
     game:exports
+
+# 身代わりセーフティありのときの除外役職一覧
+exports.SAFETY_EXCLUDED_JOBS = SAFETY_EXCLUDED_JOBS = ["QueenSpectator","Spy2","Poisoner","Cat","Cupid","BloodyMary","Noble","Twin","Hunter","MadHunter","Idol"]
 # ------ 役職一覧
 # 基本役職
 exports.jobs=["Human","Werewolf","Diviner","Psychic","Madman","Guard","Couple","Fox",
@@ -1344,17 +1347,17 @@ exports.rules=[
             {
                 name:"safety"
                 label:"身代わりセーフティ"
-                title:"「なし」や「なんでもあり」にすると身代わりくんが人狼になったりします。"
+                title:"「なんでもあり」にすると身代わりくんが人狼になったりします。"
                 type:"select"
                 values:[
                     {
                         value:"full"
-                        label:"あり"
+                        label:"身代わりくんは人外、"+SAFETY_EXCLUDED_JOBS.map((job)-> exports.getjobname(job)).join("、")+"になりません"
                         selected:true
                     }
                     {
                         value:"no"
-                        label:"なし"
+                        label:"身代わりくんは人外になりません"
                     }
                     {
                         value:"free"

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -12,7 +12,7 @@ cron=require 'cron'
 i18n = libi18n.getWithDefaultNS "game"
 
 # 身代わりセーフティありのときの除外役職一覧
-SAFETY_EXCLUDED_JOBS = ["QueenSpectator","Spy2","Poisoner","Cat","Cupid","BloodyMary","Noble","Twin","Hunter","MadHunter","Idol"]
+SAFETY_EXCLUDED_JOBS = Shared.game.SAFETY_EXCLUDED_JOBS
 # 冒涜者によって冒涜されない役職
 BLASPHEMY_DEFENCE_JOBS = ["Fugitive","QueenSpectator","Liar","Spy2","LoneWolf"]
 


### PR DESCRIPTION
This will describe this option more clearly.
And according to [this line](https://github.com/uhyo/jinrou/blob/8ad0edad6f1c7c5d246bc078d2a923c5b0d48510/server/rpc/game/game.coffee#L626) , Scapegoat is impossible to become a Werewolf by selecting ```no``` [here](https://github.com/uhyo/jinrou/blob/8ad0edad6f1c7c5d246bc078d2a923c5b0d48510/client/code/shared/game.coffee#L1356)