### PR TITLE
somehow players could join Game.participants twice in EndlessYaminabe

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -155,6 +155,11 @@ module.exports=
                     pr+=x.value
             if pr
                 name="#{Server.prize.prizeQuote pr}#{name}"
+        
+        game = games[room.id]
+        unless game && !game.participants.some((p)->p.realid==player.realid)
+            return
+
         if room.mode=="waiting"
             # 開始前（ふつう）
             log=
@@ -162,7 +167,6 @@ module.exports=
                 userid:-1
                 name:null
                 mode:"system"
-            game = games[room.id]
             if game
                 splashlog room.id, game, log
                 # プレイヤーを追加
@@ -177,7 +181,6 @@ module.exports=
                 game.participants.push newpl
         else if room.mode=="playing" && room.jobrule=="特殊ルール.エンドレス闇鍋"
             # エンドレス闇鍋に途中参加
-            game=games[room.id]
             if game
                 log=
                     comment: i18n.t "system.rooms.entering", {name: name}
@@ -1219,7 +1222,7 @@ class Game
                 for player in pcs
                     if player.isJobType "Watching"
                         # 参加待機のひとだ
-                        if !@players.some((p)->p.id==player.id)
+                        if !@players.some((p)->p.realid==player.realid)
                             # 本参加ではないのでOK
                             # 役職をランダムに決定
                             newjob=jobnames[Math.floor Math.random()*jobnames.length]
@@ -1237,6 +1240,8 @@ class Game
                                 comment: @i18n.t "system.rooms.join", {name: newpl.name}
                             splashlog @id,@,log
                             join_count++
+                        else
+                            @participants=@participants.filter (x)->x!=player
                 # たまに転生
                 deads=shuffle @players.filter (x)->x.dead && !x.norevive
                 # 転生確率


### PR DESCRIPTION
This may seem strange, but it did happen in [this room](https://www.werewolf.com.cn/room/65325) on player "Camus".
```Server.game.game.endlessCanEnter()``` failed to stop the second entering.
I am still not sure, but I suspect this is related to following bug.
> おかしいときは
> この人狼は基本的に手動の更新は不要ですが、タイミングの関係で動作がおかしくなる場合があります。たとえば他の人の発言が2重に表示されたり、時間が0になっても画面が切り替わらないときは、ブラウザの更新ボタンを押すかF5キーを押すなどしてページを更新するとだいたい直ります。

In one page, the client somehow subscribe same channel for twice, and ```room.join()``` got triggered for twice.