### PR TITLE
Magician should not choose dead player

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -3527,10 +3527,12 @@ class Magician extends Player
         if game.day<3
             # まだ発動できない
             return game.i18n.t "error.common.cannotUseSkillNow"
-        @setTarget playerid
         pl=game.getPlayer playerid
         unless pl?
             return game.i18n.t "error.common.nonexistentPlayer"
+        unless pl.dead
+            return game.i18n.t "error.common.notDead"
+        @setTarget playerid
         pl.touched game,@id
         
         log=
@@ -4626,8 +4628,12 @@ class Cat extends Poisoner
         if game.day<2
             # まだ発動できない
             return game.i18n.t "error.common.cannotUseSkillNow"
-        @setTarget playerid
         pl=game.getPlayer playerid
+        unless pl?
+            return game.i18n.t "error.common.nonexistentPlayer"
+        unless pl.dead
+            return game.i18n.t "error.common.notDead"
+        @setTarget playerid
         pl.touched game,@id
         
         log=


### PR DESCRIPTION
It looks weird, but in [this room](https://www.werewolf.com.cn/room/66028) a player(宗泽), who reincarnated at the 3rd sunrise, was listed in Magician's job selection during the 3 night.
Since I didn't find the root cause, I used this precaution.