### PR TITLE
@norevive should be transferred to newpl

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -3096,6 +3096,7 @@ class Player
         return unless newpl?
         newpl.scapegoat=@scapegoat
         newpl.setDead @dead,@found
+        newpl.setNorevive @norevive
         
             
 


### PR DESCRIPTION
In [this room](https://www.werewolf.com.cn/room/66062), player 相对的正义 set himself as norevive while he was still ```class Watching``` at the 2nd night, however his ```@norevive``` was missing after he had joined as ```class Priest```.