### PR TITLE
uncover pl.realid when it's available

### DIFF
--- a/client/code/pages/game/game.coffee
+++ b/client/code/pages/game/game.coffee
@@ -744,7 +744,7 @@ convertToJobNumbers = (obj) ->
 # Convert game.players to PlayerInfo
 convertGamePlayerToPlayerInfo = (pl) ->
     {
-        id: pl.id
+        id: if pl.realid then pl.realid else pl.id
         anonymous: !pl.realid
         name: pl.name
         dead: pl.dead


### PR DESCRIPTION
In [this line](https://github.com/uhyo/jinrou/blob/7c360d65ae17416a897470a9a36a7e9558761aae/front/src/game-view/players/box.tsx#L30), we should use `pl.realid` instead of `pl.id` if it's available.