### PR TITLE
add realid instead of replacing id into realid

### DIFF
--- a/client/code/pages/game/game.coffee
+++ b/client/code/pages/game/game.coffee
@@ -744,7 +744,8 @@ convertToJobNumbers = (obj) ->
 # Convert game.players to PlayerInfo
 convertGamePlayerToPlayerInfo = (pl) ->
     {
-        id: if pl.realid then pl.realid else pl.id
+        id: pl.id
+        realid: pl.realid || null
         anonymous: !pl.realid
         name: pl.name
         dead: pl.dead
@@ -757,6 +758,7 @@ convertGamePlayerToPlayerInfo = (pl) ->
 convertRoomPlayerToPlayerInfo = (pl) ->
     {
         id: pl.userid
+        realid: pl.realid || null
         anonymous: !pl.realid
         name: pl.name
         dead: false

--- a/front/src/game-view/defs.ts
+++ b/front/src/game-view/defs.ts
@@ -210,7 +210,11 @@ export interface PlayerInfo {
    * userid of player.
    */
   id: string;
-  /**Whether this p
+  /**
+   * realid of player.
+   */
+  realid: string | null;
+  /**
    * Whether this player is anonymized.
    */
   anonymous: boolean;

--- a/front/src/game-view/players/box.tsx
+++ b/front/src/game-view/players/box.tsx
@@ -21,13 +21,27 @@ export class PlayerBox extends React.Component<IPropPlayerBox, {}> {
   public render() {
     const {
       t,
-      player: { id, icon, name, anonymous, dead, jobname, winner, flags },
+      player: {
+        id,
+        realid,
+        icon,
+        name,
+        anonymous,
+        dead,
+        jobname,
+        winner,
+        flags,
+      },
     } = this.props;
     return (
       <Wrapper dead={dead} hasIcon={icon != null}>
         <Icon t={t} icon={icon} dead={dead} />
         <Name dead={dead}>
-          {anonymous ? name : <a href={`/user/${id}`}>{name}</a>}
+          {anonymous ? (
+            name
+          ) : (
+            <a href={`/user/${realid ? realid : id}`}>{name}</a>
+          )}
         </Name>
         <ToolIcons>
           <span onClick={this.handleFilterClick}>


### PR DESCRIPTION
The filter for highlighting player's comment relies on `PlayerInfo.id`.
[This line](https://github.com/uhyo/jinrou/blob/67928a24edcc0c292bc49cdfb6b258c0aa0891c6/client/code/pages/game/game.coffee#L747) makes it unable to highlight a certain player's comments after a room, which is ```room.rules.blind="yes"```, ended.