### PR TITLE
盗まれた人は村人？

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -9294,6 +9294,7 @@ class PhantomStolen extends Complex
     isJobType:(type)-> type == "Phantom"
     isMainJobType:(type)-> type == "Phantom"
     #team:"Human" #女王との兼ね合いで
+    getTeam:-> "Human"
     isWinner:(game,team)->
         team=="Human"
     checkDeathResistance:(game, found, from)->


### PR DESCRIPTION
https://jinrou.uhyohyo.net/room/138948
人外を盗んだ場合、次の朝にアイドル結果が、
怪盗→人外、盗まれた人→その日も人外扱いとなり、アイドル目線では村人人数がその分減る。

・内部的には既に盗まれて怪盗なのだから、村人人数に加算すべきでは？
・このような事例は今のところ怪盗処理だけなので、内訳整理に便利ではある
　今まで後者を優先していたので報告していませんでしたが、、打ち上げておきます。