### PR TITLE
警備員候補から死亡者を除外

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -8466,7 +8466,7 @@ class Hooligan extends Player
             pls = game.players.filter (x)-> !x.scapegoat && !x.dead && !x.isCmplType("HooliganMember") && !x.isJobType("Hooligan")
             pls = shuffle pls
             # 警備員の数
-            num = Math.ceil(game.players.length / 8)
+            num = Math.ceil(game.players.filter((x)-> !x.dead).length / 8)
             num = Math.min num, pls.length
             for i in [0 ... num]
                 newguard = pls[i]

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -8463,7 +8463,7 @@ class Hooligan extends Player
                 # すでに任命されていた
                 return
             # 警備員候補
-            pls = game.players.filter (x)-> !x.scapegoat && !x.isCmplType("HooliganMember") && !x.isJobType("Hooligan")
+            pls = game.players.filter (x)-> !x.scapegoat && !x.dead && !x.isCmplType("HooliganMember") && !x.isJobType("Hooligan")
             pls = shuffle pls
             # 警備員の数
             num = Math.ceil(game.players.length / 8)


### PR DESCRIPTION
https://jinrou.uhyohyo.net/room/140853
7日目夜に死亡者が警備員に任命されている。
エンドレス闇鍋しか想定していませんが、死亡者を除外。
転生すると警備員が消えるはずなので、生存者限定に。
プレイヤー人数から警備員を割り出すのではなく、生存人数から割り出したほうが良いかもしれません。→生存人数から割り出すように変更