### PR TITLE
Psychic result of Cosplayer is "werewolf"

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -7783,6 +7783,7 @@ class Forensic extends Player
 class Cosplayer extends Guard
     type:"Cosplayer"
     fortuneResult: FortuneResult.werewolf
+    psychicResult: PsychicResult.werewolf
 
 class TinyGhost extends Player
     type:"TinyGhost"


### PR DESCRIPTION
https://twitter.com/hakoniwawind/status/1091347417918652417
出典元を調べていたら、霊能結果も人狼判定だったため。

占い結果は村人を人狼と判定してしまうことが多々あるが、霊能だけは正確（悪魔くんや犬といった例外はあるが…）というイメージを勝手に持っているのでどっちでもいいかなあという気持ちはあります。
月下人狼は出典元に従うイメージも強いですが。