### PR TITLE
Liar returns only fortune result! & 予言者のママ

### DIFF
--- a/language/ja/roles.yaml
+++ b/language/ja/roles.yaml
@@ -254,7 +254,7 @@ Merchant:
 # Liar
 Liar:
   # Result.
-  resultlog: "あんまり自信ないけど、占いの結果、{{target}}は{{result}}だと思う。たぶん。"
+  resultlog: "あんまり自信ないけど、霊能占いの結果、{{target}}は{{result}}だと思う。たぶん。"
 
 # Spy2
 Spy2:

--- a/language/ja/roles.yaml
+++ b/language/ja/roles.yaml
@@ -254,7 +254,7 @@ Merchant:
 # Liar
 Liar:
   # Result.
-  resultlog: "あんまり自信ないけど、霊能占いの結果、{{target}}は{{result}}だと思う。たぶん。"
+  resultlog: "あんまり自信ないけど、占いの結果、{{target}}は{{result}}だと思う。たぶん。"
 
 # Spy2
 Spy2:
@@ -407,9 +407,9 @@ Dictator:
 # SeersMama
 SeersMama:
   # There is no seer.
-  resultNone: "{{name}}は占い師のママです。占い師はいません。"
+  resultNone: "{{name}}は予言者のママです。占い師はいません。"
   # There are one or more seer. (number is given as count)
-  result: "{{name}}は占い師のママです。占い師は{{results}}です。"
+  result: "{{name}}は予言者のママです。占い師は{{results}}です。"
 
 # Trapper
 Trapper:


### PR DESCRIPTION
今まで勘違いしていたんですが、嘘つきは死人に対して霊能結果を返しているかと思っていました。
…ということで紛らわしいので、「霊能占い」から「霊能」を削除希望です。
ついでに、役職名を統一させたく、予言者のママの能力発動時に「占い師のママ」→「予言者のママ」に改訂。