### PR TITLE
盗まれた人は人間カウントを持つ

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -9807,6 +9807,7 @@ class PhantomStolen extends Complex
     getJobname:-> @game.i18n.t "roles:jobname.Phantom" #霊界とかでは既に怪盗化
     getMainJobname:-> @getJobname()
     # 勝利条件関係は村人化（昼の間だけだし）
+    isHuman:->true
     isWerewolf:->false
     isFox:->false
     isVampire:->false


### PR DESCRIPTION
https://jinrou.uhyohyo.net/room/142967
生存11に対して狼カウント4で試合が終わっている
https://jinrou.uhyohyo.net/room/142993 でも再現

人外系はishuman:->falseとしているため、
https://github.com/uhyo/jinrou/blob/445bbb1da83ec034501a225d542517e926c442f4/server/rpc/game/game.coffee#L3002-L3004

↑より、PhantomStolenは人間カウントが0になってしまっていると推測。
そこで、PhantomStolenはishumanをtrueにしました。
間違っていたらすみません。。
