### PR TITLE
身代わりくんがコピーの場合、人外も冷遇処理をする

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -4318,6 +4318,11 @@ class Copier extends Player
                     name: pl.name
                     value: pl.id
                 }
+            else if pl.type in Shared.game.nonhumans
+                result.push {
+                    name: pl.name
+                    value: pl.id
+                }
             else
                 result.push {
                     name: pl.name


### PR DESCRIPTION
身代わりくんがコピーだった場合、人外（悪魔くん含む）をコピーする確率を減らす。
（身代わりセーフティあり役職が冷遇処理を取っているため、こちらも同様に。）