### PR TITLE
サトリを初日白通知ありに適用する

### DIFF
--- a/language/ja/roles.yaml
+++ b/language/ja/roles.yaml
@@ -795,6 +795,8 @@ DragonKnight:
   killSelect: "{{name}}が{{target}}を襲撃しました。"
 
 Satori:
+  # Today's target is automatically chosen.
+  auto: "{{name}}の今日の読心先は自動的に決定されます。"
   # select a target of mind reading.
   select: "{{name}}は{{target}}に読心術を使用しました。"
   # log of result.

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -1282,7 +1282,7 @@ class Game
                     if @rule.scapegoat=="on" && @day==1 && player.isWerewolf() && player.isAttacker()
                         # 身代わり襲撃は例外的にtrue
                         @ninja_data[player.id] = true
-                    if @rule.firstnightdivine == "auto" && @day == 1 && (player.isJobType "Diviner" || player.isJobType "Satori")
+                    if @rule.firstnightdivine == "auto" && @day == 1 && (player.isJobType("Diviner") || player.isJobType("Satori"))
                         # 初日白通知ありの占い師・サトリもtrue
                         @ninja_data[player.id] = true
         else

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -1282,8 +1282,8 @@ class Game
                     if @rule.scapegoat=="on" && @day==1 && player.isWerewolf() && player.isAttacker()
                         # 身代わり襲撃は例外的にtrue
                         @ninja_data[player.id] = true
-                    if @rule.firstnightdivine == "auto" && @day == 1 && player.isJobType "Diviner"
-                        # 初日白通知ありの占い師もtrue
+                    if @rule.firstnightdivine == "auto" && @day == 1 && (player.isJobType "Diviner" || player.isJobType "Satori")
+                        # 初日白通知ありの占い師・サトリもtrue
                         @ninja_data[player.id] = true
         else
             # 誤爆防止

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -8870,6 +8870,26 @@ class Satori extends Diviner
     type:"Satori"
     team:"Werewolf"
     formType: FormType.required
+    sunset:(game)->
+        super
+        @setTarget null
+        # 占い対象
+        targets = game.players.filter (x)->!x.dead
+
+        if @type == "Satori" && game.day == 1 && game.rule.firstnightdivine == "auto"
+            # 自動白通知
+            targets2 = targets.filter (x)=> x.id != @id && x.getFortuneResult() == FortuneResult.human && x.id != "身代わりくん" && !x.isJobType("Fox") && !x.isJobType("XianFox") && !x.isJobType("Bigwolf") && !x.isJobType("Diviner")
+            if targets2.length > 0
+                # ランダムに決定
+                log=
+                    mode:"skill"
+                    to:@id
+                    comment:game.i18n.t "roles:Satori.auto", {name: @name}
+                splashlog game.id,game,log
+
+                r=Math.floor Math.random()*targets2.length
+                @job game,targets2[r].id,{}
+                return
     sleeping:->@target?
     job:(game, playerid)->
         pl = game.getPlayer playerid

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -8878,7 +8878,7 @@ class Satori extends Diviner
 
         if @type == "Satori" && game.day == 1 && game.rule.firstnightdivine == "auto"
             # 自動白通知
-            targets2 = targets.filter (x)=> x.id != @id && x.getFortuneResult() == FortuneResult.human && x.id != "身代わりくん" && !x.isJobType("Fox") && !x.isJobType("XianFox") && !x.isJobType("Bigwolf") && !x.isJobType("Diviner")
+            targets2 = targets.filter (x)=> x.id != @id && x.getFortuneResult() == FortuneResult.human && x.id != "身代わりくん" && !x.isJobType("Fox") && !x.isJobType("XianFox") && !x.isJobType("BigWolf") && !x.isJobType("Diviner")
             if targets2.length > 0
                 # ランダムに決定
                 log=


### PR DESCRIPTION
人狼NETではサトリも初日白通知設定に影響されるため。
聞いた話では、牢獄の悪夢のパパラッチは影響されない様子。
呪殺判定持ち、強制系能力ならば適用したほうが良いと思ったので投げます。

sunsetを占い師から使いまわし。
ただし、サトリは大狼と占い師も除外しています。