### PR TITLE
闇鍋セーフティなしで血まみれのメアリーを出現させる

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -10890,7 +10890,7 @@ module.exports.actions=(req,res,ss)->
                             exceptions.push job
                             excluded_exceptions.push job
                 # メアリーの特殊処理（セーフティ高じゃないとでない）
-                if query.yaminabe_hidejobs=="" || !safety.jobs
+                if query.yaminabe_hidejobs=="" || (!safety.jobs && query.yaminabe_safety!="none")
                     exceptions.push "BloodyMary"
                     special_exceptions.push "BloodyMary"
                 # スパイ2（人気がないので出ない）


### PR DESCRIPTION
セーフティ高以上で出現と宣言はしているが、
人狼1確定以外何も制約を受けないセーフティなしでも配役して良い気がします。