### PR TITLE
チョコを食べてもストーカーに変化はしない in Chemical

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -7408,20 +7408,22 @@ class GotChocolate extends Player
                 @die game, "poison", @id
             else if r < 0.57
                 # ストーカー化
-                topl = game.getPlayer re[1]
-                if topl?
-                    newpl = Player.factory "Stalker", game
-                    top.transProfile newpl
-                    top.transferData newpl, true
-                    # ストーカー先
-                    newpl.setFlag re[1]
-                    top.transform game, newpl
+                # ケミカル人狼では何も起こらない（告発対策）
+                if @game.rule.chemical != "on"
+                    topl = game.getPlayer re[1]
+                    if topl?
+                        newpl = Player.factory "Stalker", game
+                        top.transProfile newpl
+                        top.transferData newpl, true
+                        # ストーカー先
+                        newpl.setFlag re[1]
+                        top.transform game, newpl
 
-                    log=
-                        mode:"skill"
-                        to: @id
-                        comment: game.i18n.t "roles:GotChocolate.result.stalker", {name: @name, target: topl.name}
-                    splashlog game.id, game, log
+                        log=
+                            mode:"skill"
+                            to: @id
+                            comment: game.i18n.t "roles:GotChocolate.result.stalker", {name: @name, target: topl.name}
+                        splashlog game.id, game, log
             else if r < 0.65
                 # 血入りの……
                 log=


### PR DESCRIPTION
ケミカル人狼で、チョコを食べてもストーカー変化しないように調整。

・背景
#501 ( dd3472f )
↑この修正により、ケミカル人狼においてパティシエールのチョコを食べてストーカーに変化した際、
従来はストーカー単独であったが、（恐らく）メイン役職のみがストーカーになる。
そうした場合、ケミカル人狼の勝利条件から、右側の役職陣営でも勝利が可能なため、
パティシエールの告発が容易になってしまう。

・対策
https://twitter.com/uhyo_/status/1101790069441028096