### PR TITLE
死因の変更

### DIFF
--- a/language/ja/game.yaml
+++ b/language/ja/game.yaml
@@ -252,6 +252,7 @@ foundDetail:
   gone-night: "夜間突然死"
   crafty: "死んだふり"
   greedy: "欲張りの代償"
+  tough: "捨て身"
   lunaticlover: "狂愛者の襲撃"
   hooligan: "暴動者による暴行"
   dragon: "竜の炎"

--- a/language/ja/game.yaml
+++ b/language/ja/game.yaml
@@ -251,6 +251,7 @@ foundDetail:
   gone-day: "昼間突然死"
   gone-night: "夜間突然死"
   crafty: "死んだふり"
+  greedy: "欲張りの代償"
   lunaticlover: "狂愛者の襲撃"
   hooligan: "暴動者による暴行"
   dragon: "竜の炎"

--- a/language/ja/game.yaml
+++ b/language/ja/game.yaml
@@ -251,7 +251,7 @@ foundDetail:
   gone-day: "昼間突然死"
   gone-night: "夜間突然死"
   crafty: "死んだふり"
-  greedy: "欲張りの代償"
+  greedy: "強欲の報い"
   tough: "捨て身"
   lunaticlover: "狂愛者の襲撃"
   hooligan: "暴動者による暴行"

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -1636,7 +1636,7 @@ class Game
                             # 欲張り狼がやられた!
                             gw = @getPlayer res[1]
                             if gw?
-                                gw.die this,"werewolf2"
+                                gw.die this,"greedy"
                                 gw.addGamelog this,"greedyKilled",t.type,t.id
                                 # 以降は襲撃できない
                                 flg_flg=true
@@ -1708,7 +1708,7 @@ class Game
             x = obj.pl
             situation=switch obj.found
                 #死因
-                when "werewolf","werewolf2","trickedWerewolf","poison","hinamizawa","vampire","vampire2","witch","dog","trap","marycurse","psycho","crafty","lunaticlover","hooligan","dragon","samurai"
+                when "werewolf","werewolf2","trickedWerewolf","poison","hinamizawa","vampire","vampire2","witch","dog","trap","marycurse","psycho","crafty","greedy","lunaticlover","hooligan","dragon","samurai"
                     @i18n.t "found.normal", {name: x.name}
                 when "curse"    # 呪殺
                     if @rule.deadfox=="obvious"
@@ -1748,7 +1748,7 @@ class Game
                     "marycurse","psycho","curse","punish","spygone","deathnote",
                     "foxsuicide","friendsuicide","twinsuicide","dragonknightsuicide",
                     "infirm","hunter",
-                    "gmpunish","gone-day","gone-night","crafty","lunaticlover",
+                    "gmpunish","gone-day","gone-night","crafty","greedy","lunaticlover",
                     "hooligan","dragon","samurai"
                 ].includes obj.found
                     detail = @i18n.t "foundDetail.#{obj.found}"
@@ -1763,7 +1763,7 @@ class Game
             if emma_alive.length > 0
                 # 閻魔用のログも出す
                 emma_log=switch obj.found
-                    when "werewolf","werewolf2","trickedWerewolf","crafty"
+                    when "werewolf","werewolf2","trickedWerewolf","crafty","greedy"
                         "werewolf"
                     when "poison","witch"
                         "poison"

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -1625,7 +1625,7 @@ class Game
                             flg_flg=true
                             if tw?
                                 unless tw.dead
-                                    tw.die this,"werewolf2"
+                                    tw.die this,"tough"
                                     tw.addGamelog this,"toughwolfKilled",t.type,t.id
                             break
                 unless flg_flg
@@ -1708,7 +1708,7 @@ class Game
             x = obj.pl
             situation=switch obj.found
                 #死因
-                when "werewolf","werewolf2","trickedWerewolf","poison","hinamizawa","vampire","vampire2","witch","dog","trap","marycurse","psycho","crafty","greedy","lunaticlover","hooligan","dragon","samurai"
+                when "werewolf","werewolf2","trickedWerewolf","poison","hinamizawa","vampire","vampire2","witch","dog","trap","marycurse","psycho","crafty","greedy","tough","lunaticlover","hooligan","dragon","samurai"
                     @i18n.t "found.normal", {name: x.name}
                 when "curse"    # 呪殺
                     if @rule.deadfox=="obvious"
@@ -1748,7 +1748,7 @@ class Game
                     "marycurse","psycho","curse","punish","spygone","deathnote",
                     "foxsuicide","friendsuicide","twinsuicide","dragonknightsuicide",
                     "infirm","hunter",
-                    "gmpunish","gone-day","gone-night","crafty","greedy","lunaticlover",
+                    "gmpunish","gone-day","gone-night","crafty","greedy","tough","lunaticlover",
                     "hooligan","dragon","samurai"
                 ].includes obj.found
                     detail = @i18n.t "foundDetail.#{obj.found}"
@@ -1763,7 +1763,7 @@ class Game
             if emma_alive.length > 0
                 # 閻魔用のログも出す
                 emma_log=switch obj.found
-                    when "werewolf","werewolf2","trickedWerewolf","crafty","greedy"
+                    when "werewolf","werewolf2","trickedWerewolf","crafty","greedy","tough"
                         "werewolf"
                     when "poison","witch"
                         "poison"


### PR DESCRIPTION
#548 
欲張りな狼と追加で一途な狼も、werewolf2→個別の死因へ

閻魔目線の死因は、人狼の餌食と何も変更していません。
（死んだふりの前例があるのと、文言がおかしいからといって現在のバランスを突然変えてしまうのも...）

language/ja 自分の趣味で書いてますが。↓

欲張り失敗で死亡："欲張った代償" or "強欲の報い"
PR文章書いていたときに閃いたので後者にしています。

一途な襲撃で死亡："捨て身"
「人狼ジャッジメント」の一途な人狼のキャッチコピー「想いを遂げる者」から、
"想いを遂げたことによる自害"でも良いと思いましたが、月下人狼では"捨て身の覚悟でhogeを狙っています"が襲撃ログなので素直に&簡素です。


