### PR TITLE
ニートの配役される確率を絞る

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -11428,6 +11428,10 @@ module.exports.actions=(req,res,ss)->
                 if safety.jingais || safety.jobs
                     exceptions.push "SpiritPossessed"
                     special_exceptions.push "SpiritPossessed"
+                # ニートは隠し役職（出現率低）
+                if Math.random()<0.4
+                    exceptions.push "Neet"
+                    special_exceptions.push "Neet"
 
                 # 一部闇鍋で固定されているやつが全て除外されていないかチェック
                 for type, categoryjobs of Shared.game.categories


### PR DESCRIPTION
勝利がほぼ約束されているこの役職は悪く言えばゲームをぶち壊すのに躊躇いもなく、
少々厄介な存在なので、隠し役職として（都合の良い言い訳だが、）出現確率を減らしたく。

獅子舞みたいに大幅ダウンではなく、出現率は今までの6割～7割想定で考えています。
文句も少なからず出そうですが、如何でしょうか。