### PR TITLE
add Poet in jobinfo

### DIFF
--- a/client/code/shared/game.coffee
+++ b/client/code/shared/game.coffee
@@ -786,6 +786,8 @@ exports.jobinfo=
             color:"#000d80"
         Elementaler:
             color:"#46f17f"
+        Poet:
+            color:"#f1a0a2"
 
     Werewolf:
         color:"#DD0000"


### PR DESCRIPTION
色情報以外でも陣営数計算にjobinfoを使用しているみたいなので、 #568 が直るかと
取り急ぎ歌人の色は俳句の背景色と同じにしていますが、拘りなどあれば修正案をお願いします。