### PR TITLE
特定の役職を除外する

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -11645,7 +11645,7 @@ module.exports.actions=(req,res,ss)->
                     exceptions.push "MadWolf"
                     special_exceptions.push "MadWolf"
                 # ニートは隠し役職（出現率低）
-                if Math.random()<0.4
+                if query.losemode == "on" || Math.random()<0.4
                     exceptions.push "Neet"
                     special_exceptions.push "Neet"
 

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -11640,6 +11640,10 @@ module.exports.actions=(req,res,ss)->
                 if safety.jingais || safety.jobs
                     exceptions.push "SpiritPossessed"
                     special_exceptions.push "SpiritPossessed"
+                # 狂人狼（人気がないので出ない）
+                if safety.jingais || safety.jobs
+                    exceptions.push "MadWolf"
+                    special_exceptions.push "MadWolf"
                 # ニートは隠し役職（出現率低）
                 if Math.random()<0.4
                     exceptions.push "Neet"


### PR DESCRIPTION
①狂人狼は人気がない
　常に告発ゲームとなってしまうため。
②敗北村でニートを除外
　ほぼほぼ敗北となってしまう上に通常のプレイでは除外もできないため。