### PR TITLE
反撃のランダム死で孤独な狼は対象外にする

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -1282,7 +1282,7 @@ class Game
                 @werewolf_target_remain=1
             else if @rule.scapegoat=="on"
                 # 誰が襲ったかはランダム
-                onewolf=@players.filter (x)->x.isWerewolf()
+                onewolf=@players.filter (x)->x.isWerewolf() && x.isAttacker()
                 if onewolf.length>0
                     r=Math.floor Math.random()*onewolf.length
                     @werewolf_target.push {
@@ -3968,7 +3968,7 @@ class Poisoner extends Player
                 # 襲撃者を道連れにする
                 canbedead = canbedead.filter (x)->x.id==from
             else
-                canbedead=canbedead.filter (x)->x.isWerewolf()
+                canbedead=canbedead.filter (x)->x.isWerewolf() && x.isAttacker()
         else if found=="vampire"
             canbedead=canbedead.filter (x)->x.id==from
         return if canbedead.length==0
@@ -10443,7 +10443,7 @@ class TrapGuarded extends Complex
             if found == "vampire"
                 canbedead=game.players.filter (x)->!x.dead && x.id==from
             else
-                canbedead=game.players.filter (x)->!x.dead && x.isWerewolf()
+                canbedead=game.players.filter (x)->!x.dead && x.isWerewolf() && x.isAttacker()
             if canbedead.length > 0
                 r=Math.floor Math.random()*canbedead.length
                 pl=canbedead[r] # 被害者


### PR DESCRIPTION
爆弾などの反撃で孤独な狼が対象になる事例がありました。
https://jinrou.uhyohyo.net/room/152062

確かにランダムで死亡するのですが、襲撃していない孤独な狼まで含まれるのはどうなのか？という話です。

爆弾魔はランダムではなく襲撃先が死にますが、恐らく身代わりくん襲撃がランダムだったから死亡したと思われます。
本Pullreqでは、身代わりくんの襲撃元、埋毒者猫又罠師のランダム死対象から孤独な狼を除外しています。