### PR TITLE
絶対狼を生存させることで追加勝利になり得る役職の処置

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -9698,7 +9698,8 @@ class AbsoluteWolf extends Werewolf
         if @getTeam() != "Werewolf"
             return false
         # 追加勝利も許さない
-        if @isCmplType("HooliganMember") || @isCmplType("LunaticLoved")
+        me = game.getPlayer @id
+        if me.isCmplType("HooliganMember") || me.isCmplType("LunaticLoved")
             return false
         # 残りの狼の数と絶対狼の数が一致していたら喪失
         wolves=game.players.filter (x)->x.isWerewolf() && !x.dead

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -9697,6 +9697,9 @@ class AbsoluteWolf extends Werewolf
         # 陣営変化していたら喪失
         if @getTeam() != "Werewolf"
             return false
+        # 追加勝利も許さない
+        if @isCmplType("HooliganMember") || @isCmplType("LunaticLoved")
+            return false
         # 残りの狼の数と絶対狼の数が一致していたら喪失
         wolves=game.players.filter (x)->x.isWerewolf() && !x.dead
         awolves=wolves.filter (x)->x.isJobType "AbsoluteWolf"


### PR DESCRIPTION
暴徒、狂愛者は絶対狼を選択することによって有利になると考えます。
厳密に言えば陣営変化ではないものの、暴動者や狂愛された場合も絶対的な力を剥奪する仕様変更です。
暴動者は警備員によって取り除けますので、そこら辺で夜襲撃役職と被った場合ちょっと複雑かもしれません。