### PR TITLE
陣営変化で死亡耐性が剥がれる

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -9701,10 +9701,10 @@ class AbsoluteWolf extends Werewolf
             # If this is a gone death, do not guard.
             return false
         # 陣営変化していたら喪失
-        if @getTeam() != "Werewolf"
+        me = game.getPlayer @id
+        if me.getTeam() != "Werewolf"
             return false
         # 追加勝利も許さない
-        me = game.getPlayer @id
         if me.isCmplType("HooliganMember") || me.isCmplType("LunaticLoved")
             return false
         # 残りの狼の数と絶対狼の数が一致していたら喪失
@@ -11132,7 +11132,8 @@ class SacrificeProtected extends Complex
         if found in ["gone-day","gone-night"]
             # If this is a gone death, do not guard.
             return false
-        if @getTeam() != "Human"
+        me = game.getPlayer @id
+        if me.getTeam() != "Human"
             return false
         # 生贄先が生存していないとダメ
         sacrifice=game.getPlayer @cmplFlag


### PR DESCRIPTION
#617 

人身御供も同じように変更しました。
（人身御供能力発動→何らかの要因で誘惑する女狼死亡→陣営変化→襲撃など・・・で
同じく能力が発動してしまうため。）