### PR TITLE
配役の調整

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -12272,6 +12272,21 @@ module.exports.actions=(req,res,ss)->
                 if safety.jingais || safety.jobs
                     exceptions.push "MadWolf"
                     special_exceptions.push "MadWolf"
+                # 闇道化
+                if safety.jingais || safety.jobs
+                    exceptions.push "DarkClown"
+                    special_exceptions.push "DarkClown"
+                # 絶対狼
+                if Math.random()<0.4
+                    exceptions.push "AbsoluteWolf"
+                    special_exceptions.push "AbsoluteWolf"
+                # 村人表記シリーズ
+                if Math.random()<0.3
+                    exceptions.push "Oracle"
+                    special_exceptions.push "Oracle"
+                if Math.random()<0.3
+                    exceptions.push "Fate"
+                    special_exceptions.push "Fate"
                 # ニートは隠し役職（出現率低）
                 if query.losemode == "on" || Math.random()<0.4
                     exceptions.push "Neet"


### PR DESCRIPTION
試験期間終了ということで…。

・闇道化
　予想通り、ゲームがまるっきり変わってしまうので不評でした。→配役をやめる
・絶対狼
　陣営変化なしがわかってしまうゲームではただ浮いているだけって感じがして、絞ったほうが良いと判断。
・村人表記系列
　単純に村人名義の役になることが増えるため。