### PR TITLE
fix: one-day limited skills unexpectedly prolonged

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -11011,8 +11011,8 @@ class DivineObstructed extends Complex
     cmplType:"DivineObstructed"
     sunsetAlways:(game)->
         # 一日しか守られない
-        @mcall game,@main.sunset,game
-        @sub?.sunset? game
+        @mcall game,@main.sunsetAlways,game
+        @sub?.sunsetAlways? game
         @uncomplex game
     # 占いの影響なし
     divineeffect:(game)->
@@ -11246,8 +11246,8 @@ class DivineCursed extends Complex
     cmplType:"DivineCursed"
     sunsetAlways:(game)->
         # 1日で消える
-        @mcall game,@main.sunset,game
-        @sub?.sunset? game
+        @mcall game,@main.sunsetAlways,game
+        @sub?.sunsetAlways? game
         @uncomplex game
     divined:(game,player)->
         @mcall game,@main.divined,game,player


### PR DESCRIPTION
e.g. DivineCursed(MikoProtected).
MikoProtected could not uncomplex as planned, if the player got DivineObstructed or DivineCursed.