### PR TITLE
fix: special jobs losts discount on prize counter

### DIFF
--- a/server/prizedata.coffee
+++ b/server/prizedata.coffee
@@ -65,7 +65,7 @@ loadTable=(arr)->
     normaljobs=["all","Human","Werewolf","Diviner","Psychic","Madman","Guard","Couple","Fox"]
     # 数をパースする
     for num in nums
-        res=num.match /^(\d+)(?:\(\d+\))?$/
+        res=num.match /^(\d+)(?:\()?(\d+\))?$/
         if res
             normals.push parseInt res[1]
             if res[2]?


### PR DESCRIPTION
If I didn't get you wrong, you intends to give those special jobs a discount on prize counter in [this block](https://github.com/uhyo/jinrou/blob/1e0a9571df96ee468073a5ff8ed152c6bf18e840/server/prizedata.coffee#L67-L74) and [this win_sample.csv](https://github.com/uhyo/jinrou/blob/1e0a9571df96ee468073a5ff8ed152c6bf18e840/prizedata/win_sample.csv).
However, former RegExp makes ```res[2]``` always unavailable.

By merging this PR, players would 
1. gain prize of special jobs explosively, 
2. must set their ```.nowprize``` again before their "nowprize" could display properly. 