### PR TITLE
fix: inner fascinatesuicide could not be triggered

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -11744,6 +11744,7 @@ class StreamerTrial extends Complex
 class Fascinated extends Complex
     cmplType:"Fascinated"
     beforebury:(game,type,deads)->
+        super
         unless @dead
             pl=game.getPlayer @cmplFlag
             if pl? && pl.dead


### PR DESCRIPTION
If player was fascinated by two different QueenOfNight, he would not suicide after the earlier QueenOfNight dead, because ```class Complex.beforebury()``` was overwritten.