### PR TITLE
ローレライを隠し役職にする

### DIFF
--- a/client/code/shared/game.coffee
+++ b/client/code/shared/game.coffee
@@ -80,11 +80,11 @@ exports.jobs=["Human","Werewolf","Diviner","Psychic","Madman","Guard","Couple","
 "SantaClaus","Reindeer",
 "Pyrotechnist","Patissiere","Shishimai","Idol","LurkingMad",
 "DecoyWolf","Hooligan","HomeComer","DragonKnight","Poet","Sacrifice",
-"Synesthete","Streamer","RemoteWorker","Lorelei"
+"Synesthete","Streamer","RemoteWorker"
 ]
 # 隠されていて自分で入れることができない役職
 exports.hiddenJobs = [
-    "Light", "Neet", "MinionSelector", "QuantumPlayer", "HolyProtected", "Lorelei"
+    "Light", "Neet", "MinionSelector", "QuantumPlayer", "HolyMarked", "Lorelei"
 ]
 
 # 人外


### PR DESCRIPTION
少人数でのプレイを想定していないため、固定禁止役職にしたく。