### PR TITLE
fix Endless loop related to Lorelei

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -13269,7 +13269,8 @@ module.exports.actions=(req,res,ss)->
                     category = null
                     job = null
                     team = null
-                    while true
+                    sub_counter = 0
+                    while sub_counter++ < 300
                         # 前のループで確保したものが残っていたら返す
                         if category? || team?
                             if category?


### PR DESCRIPTION
In 一部闇鍋, if 
1. room owner excludes all jobs of 第三陣営系 other than Lorelei,
2. asks multiple 第三陣営系 jobs,
3. players number of this room is less than 13,

it will become an endless loop.