### PR TITLE
課金者が死亡したときは役職変化しない

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -9962,7 +9962,7 @@ class GachaAddicted extends Player
             return null
 
     midnight:(game)->
-        if @flag?.status == "transforming"
+        if @flag?.status == "transforming" && !@dead
             # 実際に変化する
             newpl = Player.factory @flag.job, game
             @transProfile newpl


### PR DESCRIPTION
公式ドキュメントより
>その夜に死亡した場合は変化しません。

役職変化中に人狼の襲撃を受けて死亡するが、ゲーム終了時に役職変化していると指摘を受けました。
