### PR TITLE
盗人をその他扱いにする

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -5637,6 +5637,7 @@ class MinionSelector extends Player
 # 盗人
 class Thief extends Player
     type:"Thief"
+    team:""
     isWinner:-> false
     formType: FormType.required
     sleeping:(game)->@target?


### PR DESCRIPTION
戦績表示や開始時の陣営情報ではその他だが、マニュアルが村人陣営になっていると指摘を受けたため。