### PR TITLE
fix oni , absolutewolf

### DIFF
--- a/client/code/shared/game.coffee
+++ b/client/code/shared/game.coffee
@@ -2,7 +2,7 @@ Shared=
     game:exports
 
 # 身代わりセーフティありのときの除外役職一覧
-exports.SAFETY_EXCLUDED_JOBS = SAFETY_EXCLUDED_JOBS = ["QueenSpectator","Spy2","Poisoner","Cat","Cupid","BloodyMary","Noble", "Lover", "Twin","Hunter","MadHunter","Idol","SnowLover","Raven","LunaticLover","HooliganGuard","HooliganAttacker","SantaClaus"]
+exports.SAFETY_EXCLUDED_JOBS = SAFETY_EXCLUDED_JOBS = ["QueenSpectator","Spy2","Poisoner","Cat","Cupid","BloodyMary","Noble", "Lover", "Twin","Hunter","MadHunter","Idol","SnowLover","Raven","LunaticLover","HooliganGuard","HooliganAttacker","SantaClaus","Oni"]
 # ------ 役職一覧
 # 基本役職
 exports.jobs=["Human","Werewolf","Diviner","Psychic","Madman","Guard","Couple","Fox",

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -9782,8 +9782,8 @@ class AbsoluteWolf extends Werewolf
         me = game.getPlayer @id
         if me.getTeam() != "Werewolf"
             return false
-        # 追加勝利も許さない
-        if me.isCmplType("HooliganMember") || me.isCmplType("LunaticLoved")
+        # 追加勝利も許さない＆絆化していたら死ぬ
+        if me.isCmplType("HooliganMember") || me.isCmplType("LunaticLoved") || me.isCmplType("Bonds")
             return false
         # 残りの狼の数と絶対狼の数が一致していたら喪失
         wolves=game.players.filter (x)->x.isWerewolf() && !x.dead

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -84,9 +84,10 @@ PsychicResult =
     # priority of resutls in chemical.
     _chemicalPriority:
         human: 0
-        werewolf: 1
-        BigWolf: 2
-        TinyFox: 2
+        oni: 1
+        werewolf: 2
+        BigWolf: 3
+        TinyFox: 3
     # function to combine two results in chemical.
     # filter out low priority results.
     combineChemical: (res1, res2)->
@@ -12436,6 +12437,8 @@ class Chemical extends Complex
             FortuneResult.vampire
         else if FortuneResult.werewolf in [fsm, fss]
             FortuneResult.werewolf
+        else if FortuneResult.oni in [fsm, fss]
+            FortuneResult.oni
         else
             FortuneResult.human
     getPsychicResult:->


### PR DESCRIPTION
①ケミカル人狼だと鬼の占いと多分霊能結果が人間になっているので修正。
　鬼は陣営ではないので、優先度は低めに設定。（今後鬼陣営を作成するならば要検討か。）
　占い：ヴァンパイア＞人狼＞鬼
　霊能：子狐＆大狼＞人狼＞鬼

②鬼を身代わりセーフティで出現させない。
　確率で耐える＆ランダム攫いの展開はプレイヤー側は面白くないため。

③絶対狼は絆付与で死亡させる。
　後追い自殺しないという話があったため…。
　現状、絆付与は悪戯妖精しか存在しないので妖狐に対して圧倒的に人狼不利ですが…そのうち妖狐陣営以外も絆付与持ち増えるでしょうということで。