### PR TITLE
闇狼生存時は観戦者も投票結果を隠す

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -14555,12 +14555,14 @@ islogOK=(game,player,log)->
             game.getPlayer player.flag
         else
             player
+    alives = game.players.filter (x)->!x.dead && x.isJobType("DarkWolf")
+
     unless actpl?
         # 観戦者
         if log.mode in ["day","system","prepare","nextturn","audience","will","gm","gmaudience","probability_table"]
             !log.to?    # 観戦者にも公開
         else if log.mode=="voteresult"
-            game.rule.voteresult!="hide"    # 投票結果公開なら公開
+            game.rule.voteresult!="hide" && alives.length==0 # 投票結果公開なら公開
         else
             false   # その他は非公開
     else if log.mode=="gmmonologue"


### PR DESCRIPTION
2窓対策をしないと不味いという指摘が多数あったので。