### PR TITLE
一部の役職を霊界表示なしにさせる

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -4209,6 +4209,7 @@ class Spy extends Player
 class WolfDiviner extends Werewolf
     type:"WolfDiviner"
     midnightSort:120
+    isReviver:->!@dead
     constructor:->
         super
         @setFlag {
@@ -9889,6 +9890,7 @@ class NightRabbit extends Fox
 class GachaAddicted extends Player
     type:"GachaAddicted"
     midnightSort: 122
+    isReviver:->!@dead
     constructor:->
         super
         @setFlag {
@@ -10078,6 +10080,7 @@ class GachaAddicted extends Player
 class Fate extends Player
     type:"Fate"
     midnightSort:122
+    isReviver:->!@dead
     getTypeDisp:->
         if @flag == "done"
             super
@@ -10218,6 +10221,7 @@ class Streamer extends Player
     type: "Streamer"
     getSpeakChoice:(game)->
         ["streaming", "-monologue"].concat super
+    isReviver:->!@dead
     sunset:(game)->
         unless @flag?
             # equip self with StreamerTrial


### PR DESCRIPTION
配信者が魔女をやってみたときに、霊界情報を開示されて荒れていたため。

配信者よりは可能性低いですが、他の変化系役職も同様に生存中禁止にさせます。
（該当役職：人狼占い、課金者、運命の子、配信者）

コピーやドッペルゲンガー、フランケンシュタインの怪物については、蘇生役職が存在しないとこの事例は起こらないため問題ないです。