### PR TITLE
fix SpentVotesForGacha

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -12450,9 +12450,9 @@ class SpentVotesForGacha extends Complex
         # 自分の票数を引く
         game.votingbox.votePower this, -@cmplFlag
     # 夜になったら消える
-    sunset:(game)->
-        @mcall game, @main.sunset, game
-        @sub?.sunset? game
+    sunsetAlways:(game)->
+        @mcall game, @main.sunsetAlways, game
+        @sub?.sunsetAlways? game
         @uncomplex game
 
 # 配信者のサブ役職管理


### PR DESCRIPTION
https://jinrou.uhyohyo.net/room/196227
課金者の投票数の減少が血狼や威嚇する狼の能力で継続するバグ修正