### PR TITLE
add 暗殺反射

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -3453,6 +3453,7 @@ class Player
     # 死亡させられそうな場合に耐性をチェック
     # Returns true if it resisted its death.
     checkDeathResistance:-> false
+    assassinationReflectivity: 0
     # 殺されたとき(found:死因。fromは場合によりplayerid。punishの場合は[playerid]))
     die:(game,found,from)->
         return if @dead
@@ -4685,7 +4686,9 @@ class Light extends Player
     midnight:(game,midnightSort)->
         t=game.getPlayer game.skillTargetHook.get @target
         # デスノートで殺す
-        if t? && !t.dead
+        if t.assassinationReflectivity > 0 && Math.random() < t.assassinationReflectivity
+            @die game, "deathnote", t.id
+        else if t? && !t.dead
             t.die game, "deathnote", @id
 
         # 誰かに移る処理
@@ -10748,6 +10751,7 @@ class Oni extends Player
     psychicResult: PsychicResult.oni
     # 鬼の人さらい減衰率
     attenuationRate: 0.2
+    assassinationReflectivity: 0.3
     hasDeadResistance:-> true
     sleeping:->true
     jobdone:->@target?
@@ -10795,7 +10799,9 @@ class Oni extends Player
         successRate = Math.pow @attenuationRate, successCount
         if successRate < 0.01
             successRate = 0.01
-        if Math.random() < successRate
+        if pl.assassinationReflectivity > 0 && Math.random() < pl.assassinationReflectivity
+            @die game, "oni", pl.id
+        else if Math.random() < successRate
             pl.die game, "oni", @id
             @setFlag Object.assign {}, @flag, {
                 successCount: successCount + 1
@@ -10885,6 +10891,7 @@ class Hanami extends Player
 class GoldOni extends Oni
     type: "GoldOni"
     attenuationRate: 0.5
+    assassinationReflectivity: 0.4
     constructor:->
         super
 

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -4686,9 +4686,7 @@ class Light extends Player
     midnight:(game,midnightSort)->
         t=game.getPlayer game.skillTargetHook.get @target
         # デスノートで殺す
-        if t.assassinationReflectivity > 0 && Math.random() < t.assassinationReflectivity
-            @die game, "deathnote", t.id
-        else if t? && !t.dead
+        if t? && !t.dead
             t.die game, "deathnote", @id
 
         # 誰かに移る処理


### PR DESCRIPTION
鬼陣営の持つ暗殺反射能力の追加です。
現状、鬼の人攫いのみ対応。
デスノートは人狼式で暗殺扱いですが、例外として反射無効となっていたので除外。