### PR TITLE
細かい修正

### DIFF
--- a/language/ja/game.yaml
+++ b/language/ja/game.yaml
@@ -8,6 +8,7 @@ common:
   chemicalWerewolf: 'ケミカル人狼'
   # 敗北村
   losemode: '敗北村'
+  ushi: '2陣営戦'
 # Error messages
 error:
   # Common error message

--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -10985,7 +10985,7 @@ class Reincarnator extends Player
     dying:(game,found)->
         super
         # 死体
-        deads = game.players.filter (x)->x.dead && !x.found && !x.norevive && !x.scapegoat && x.id != @id && x.isHuman() && !x.isJobType("Devil")
+        deads = game.players.filter (x)->x.dead && !x.found && !x.norevive && !x.scapegoat && x.id != @id && !(x.type in Shared.game.nonhumans)
         if deads.length==0
             return
         pl=deads[Math.floor(Math.random()*deads.length)]
@@ -11047,7 +11047,7 @@ class Duelist extends Player
         log=
             mode:"skill"
             to:newpl.id
-            comment: game.i18n.t "roles:Duelist.become", {name: pl.name, target: @name}
+            comment: game.i18n.t "roles:Duelist.become", {name: @name, target: pl.name}
         splashlog game.id,game,log
         # 2人とも更新する
         game.splashjobinfo [mytop, pl]
@@ -14471,6 +14471,9 @@ module.exports.actions=(req,res,ss)->
             if query.yaminabe_hidejobs != "" && query.jobrule == "特殊ルール.自由配役"
                 # ルール名のみ
                 ruleinfo_str = game.i18n.t "casting:castingName.#{query.jobrule}"
+            if query.ushi == "on"
+                # 2陣営戦の場合は表示
+                ruleinfo_str = "#{game.i18n.t "common.ushi"}　" + (ruleinfo_str ? "")
             if query.losemode == "on"
                 # 敗北村の場合は表示
                 ruleinfo_str = "#{game.i18n.t "common.losemode"}　" + (ruleinfo_str ? "")


### PR DESCRIPTION
特に問題ない項目だと思いますが、以下をサイレント修正

①転生者の蘇生対象外である人外判定をnonhumansに従う
②決闘者から決闘を申し込まれた側の表示メッセージの修正
③2陣営戦にチェックが入った場合は開始時に知らせる（除外役職騙り防止のため）