### PR TITLE
2陣営戦で除外しても村人が出現してしまう

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -13847,7 +13847,8 @@ module.exports.actions=(req,res,ss)->
                             joblist.team_Human += diff
                             frees -= diff
 
-                        addTeamToExceptions "Human"
+                        if query.ushi!="on"
+                            addTeamToExceptions "Human"
                     # ヴァンパイア陣営
                     if frees > 0 && (joblist.Vampire > 0 || joblist.Dracula > 0)
                         if joblist.Vampire + joblist.Dracula == 1


### PR DESCRIPTION
闇鍋セーフティの陣営調整したまま2陣営戦ありにするとそれなりの確率で村人が出現する不具合の修正です。

陣営数調整すると、possibilityの数が強制的に0になってしまうため村人が配役されていました。すみません。
例外的に2陣営戦ありの場合>addTeamToExceptions "Human"を外して残りは村人陣営を出現させるようにします。