### PR TITLE
護衛されたときに能力がはたらかない in Chemical

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -11678,6 +11678,9 @@ class Complex
     divined:(game,player)->
         @mcall game,@main.divined,game,player
         @sub?.divined? game,player
+    whenguarded:(game,player)->
+        @mcall game,@main.whenguarded,game,player
+        @sub?.whenguarded? game,player
     touched:(game, from)->
         @mcall game, @main.touched, game, from
         @sub?.touched game, from
@@ -11748,6 +11751,12 @@ class Complex
         if @mcall game, @main.hasDeadResistance, game
             return true
         if @sub?.hasDeadResistance game
+            return true
+        return false
+    hasDeadlyWeapon:(game)->
+        if @mcall game, @main.hasDeadlyWeapon, game
+            return true
+        if @sub?.hasDeadlyWeapon game
             return true
         return false
     getAttribute:(attr, game)->


### PR DESCRIPTION
ケミカル人狼で月下美人・直感派狼・月狼が右側にあるときに護衛されても能力がはたらかない不具合の修正です。

直近PR送った遺品整理士についてもケミカル用の処理をこちらで加えておきます。