### PR TITLE
転生者が突然死した場合は蘇生させない

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -11013,18 +11013,19 @@ class Reincarnator extends Player
     isReviver:->true
     dying:(game,found)->
         super
-        # 死体
-        deads = game.players.filter (x)->x.dead && !x.found && !x.norevive && !x.scapegoat && x.id != @id && !(x.type in Shared.game.nonhumans)
-        if deads.length==0
-            return
-        pl=deads[Math.floor(Math.random()*deads.length)]
-        @addGamelog game, "reincarnation", null, pl.id
-        log=
-            mode:"hidden"
-            to:-1
-            comment: game.i18n.t "roles:Reincarnator.revive", {name: @name, target: pl.name}
-        splashlog game.id,game,log
-        pl.revive game
+        unless found in ["gone-day", "gone-night"]
+            # 死体
+            deads = game.players.filter (x)->x.dead && !x.found && !x.norevive && !x.scapegoat && x.id != @id && !(x.type in Shared.game.nonhumans)
+            if deads.length==0
+                return
+            pl=deads[Math.floor(Math.random()*deads.length)]
+            @addGamelog game, "reincarnation", null, pl.id
+            log=
+                mode:"hidden"
+                to:-1
+                comment: game.i18n.t "roles:Reincarnator.revive", {name: @name, target: pl.name}
+            splashlog game.id,game,log
+            pl.revive game
 
 class Duelist extends Player
     type:"Duelist"


### PR DESCRIPTION
https://jinrou.uhyohyo.net/room/200687
猶予時間を過ぎ、未投票で突然死した場合蘇生した側も連鎖的に突然死してしまう。
赤ずきんのようにbeforeburyで処理させた場合は恐らく大丈夫だと思われますが、確かめるのも面倒なのでハンターのように能力は発動させないように変更します。