### PR TITLE
fix SacrificeProtected

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -12787,7 +12787,7 @@ class DraculaBitten extends Complex
 class SacrificeProtected extends Complex
     cmplType:"SacrificeProtected"
     checkDeathResistance:(game, found)->
-        if found in ["gone-day","gone-night"]
+        if found in ["gone-day","gone-night","sacrifice"]
             # If this is a gone death, do not guard.
             return false
         me = game.getPlayer @id


### PR DESCRIPTION
fix #754

少し考えましたが、良さげな案がないので、
素直にsacrificeが死因のときは処理をキャンセルする方向にしておきます。

ただし、今後何らかの死を他者に押し付けるシステムが出てきた際に、再度この問題に直面します。
