### PR TITLE
転生者は他の転生者を蘇生させない

### DIFF
--- a/server/rpc/game/game.coffee
+++ b/server/rpc/game/game.coffee
@@ -11031,7 +11031,7 @@ class Reincarnator extends Player
         unless found in ["gone-day", "gone-night"]
             # 死体
             deads = game.players.filter (x)=>
-                if !(x.dead && !x.found && !x.norevive && !x.scapegoat && x.id != @id)
+                if !(x.dead && !x.found && !x.norevive && !x.scapegoat && x.id != @id && !x.isJobType("Reincarnator"))
                     return false
                 # 人外は除く
                 return getAllMainRoles(x).every((role)-> !(role.type in Shared.game.nonhumans))


### PR DESCRIPTION
転生者が複数居る場合、人狼陣営が著しく不利になるため。
若しくは、1度だけの能力に調整しても良いかもしれません。

https://jinrou.uhyohyo.net/room/202325
例は転生者*2、フランケンシュタインの怪物が偶然出た村