### PR TITLE
Add PrizeStatus view to display conditions and progress

### DIFF
--- a/front/src/api/prize-status.ts
+++ b/front/src/api/prize-status.ts
@@ -1,0 +1,20 @@
+/**
+ * An API to fetch the status of all prizes (conditions and progress)
+ * of the logged-in user.
+ * TODO: it depends directly on the legacy ss api.
+ */
+import { PrizeStatus } from '../pages/prize/defs';
+
+export function getPrizeStatus(): Promise<PrizeStatus | null> {
+  return new Promise(resolve => {
+    (window as any).ss.rpc('user.getPrizeStatus', (result: any) => {
+      if (!result || result.error) {
+        // failure
+        console.error(result && result.error);
+        resolve(null);
+      } else {
+        resolve(result.statuses != null ? result.statuses : []);
+      }
+    });
+  });
+}

--- a/front/src/pages/prize/component.tsx
+++ b/front/src/pages/prize/component.tsx
@@ -5,6 +5,7 @@ import { PrizeStore } from './store';
 import { observer } from 'mobx-react';
 import { PageWrapper, Reminder, SaveButton, NowPrizeWrapper } from './elements';
 import { PrizeList } from './prize-list';
+import { PrizeStatus } from './status';
 import { ConjucntionList } from './nowprize/conjunctions';
 import { NowPrizeList } from './nowprize';
 import { WideButton } from '../../common/button';
@@ -40,6 +41,8 @@ export class PrizePage extends React.Component<IPropPrize, {}> {
           <h2>{i18n.t('list.title')}</h2>
           <p>{i18n.t('list.prizeNumber', { count: store.prizeNumber })}</p>
           <PrizeList i18n={i18n} store={store} />
+
+          <PrizeStatus i18n={i18n} store={store} />
 
           <h2>{i18n.t('edit.title')}</h2>
           <p>{i18n.t('edit.description')}</p>

--- a/front/src/pages/prize/defs.ts
+++ b/front/src/pages/prize/defs.ts
@@ -33,6 +33,76 @@ export type NowPrize =
 export type NowPrizeType = NowPrize['type'];
 
 /**
+ * Series of prize.
+ */
+export type PrizeStatusSeries =
+  | 'wincount'
+  | 'losecount'
+  | 'winteamcount'
+  | 'counter'
+  | 'ownprizes';
+
+/**
+ * Data of status of a prize (condition and progress).
+ */
+export interface PrizeStatusRow {
+  /**
+   * ID of prize.
+   */
+  id: string;
+  /**
+   * Series of the prize.
+   */
+  series: PrizeStatusSeries;
+  /**
+   * Key of the subgroup (job / team / counter type).
+   */
+  kind: string;
+  /**
+   * Key of the team which the job belongs to.
+   * Only for wincount/losecount rows: "all" means overall (全職業),
+   * otherwise a team key of shared/game.coffee (e.g. "Human").
+   * Always null for other series.
+   */
+  team?: string | null;
+  /**
+   * Required count to achieve the prize.
+   */
+  required: number;
+  /**
+   * Current count.
+   */
+  current: number;
+  /**
+   * Whether the prize is achieved.
+   */
+  achieved: boolean;
+  /**
+   * Displayed name of the prize.
+   */
+  name: string;
+  /**
+   * Phonetic of the prize.
+   * Not displayed for now (reserved for future use such as search).
+   */
+  phonetic: string;
+  /**
+   * Localized name of job (only for wincount/losecount).
+   */
+  jobName?: string | null;
+  /**
+   * Localized name of team (winteamcount rows, and the team of the job for
+   * wincount/losecount rows). Null for wincount/losecount of "all".
+   */
+  teamName?: string | null;
+}
+
+/**
+ * Status of all prizes.
+ */
+export type PrizeStatus = PrizeStatusRow[];
+
+/**
  * Currently selected prize
  */
 export type PrizeSelection =

--- a/front/src/pages/prize/status/elements.tsx
+++ b/front/src/pages/prize/status/elements.tsx
@@ -1,0 +1,170 @@
+import styled from '../../../util/styled';
+import {
+  activeButtonColor,
+  helperTextColor,
+  lightBorderColor,
+  noColor,
+  yesColor,
+} from '../../../common/color';
+import { phone } from '../../../common/media';
+
+/**
+ * Wrapper of the prize status (称号图鉴) section.
+ */
+export const StatusSection = styled.section`
+  margin: 1.2em 0;
+  padding: 0 20px;
+  border: 1px solid ${lightBorderColor};
+`;
+
+/**
+ * Title of the status section.
+ */
+export const StatusTitle = styled.h2`
+  font-size: 1.2em;
+`;
+
+/**
+ * Description of the status section.
+ */
+export const StatusDescription = styled.p`
+  font-size: 0.85em;
+  color: ${helperTextColor};
+  margin: 0.4em 0;
+`;
+
+/**
+ * Wrapper of one series.
+ */
+export const StatusSeries = styled.section`
+  margin: 0.8em 0;
+`;
+
+/**
+ * Title of one series.
+ */
+export const StatusSeriesTitle = styled.h3`
+  font-size: 1.05em;
+  margin: 0.5em 0 0.2em;
+`;
+
+/**
+ * Sub-group of a series.
+ */
+export const StatusGroup = styled.details`
+  margin: 0.2em 0;
+`;
+
+/**
+ * Summary of a sub-group.
+ */
+export const StatusGroupSummary = styled.summary`
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 0.95em;
+`;
+
+/**
+ * Label of a win / lose subsection inside a job group.
+ */
+export const StatusKindLabel = styled.span`
+  display: block;
+  margin: 0.4em 0 0.1em;
+  font-size: 0.9em;
+  font-weight: bold;
+  color: ${helperTextColor};
+`;
+
+/**
+ * A job group nested inside a team group (indented to show subordination).
+ */
+export const StatusJobGroup = styled.details`
+  margin: 0.2em 0 0.2em 1.4em;
+  padding-left: 0.8em;
+  border-left: 1px solid ${lightBorderColor};
+`;
+
+/**
+ * Indented content block directly under a team group (e.g. the win/lose
+ * subsections of the "all" team).
+ */
+export const StatusIndent = styled.div`
+  margin: 0.2em 0 0.2em 1.4em;
+  padding-left: 0.8em;
+  border-left: 1px solid ${lightBorderColor};
+`;
+
+/**
+ * List of prize status rows.
+ */
+export const StatusList = styled.ol`
+  margin: 0.2em 0;
+  padding-left: 1.4em;
+`;
+
+/**
+ * One prize status row.
+ */
+export const StatusRowItem = styled.li`
+  margin: 0.15em 0;
+  line-height: 1.6;
+
+  ${phone`
+    margin: 0.25em 0;
+  `};
+`;
+
+/**
+ * Displayed name of a prize.
+ */
+export const StatusPrizeName = styled.span`
+  font-weight: bold;
+`;
+
+/**
+ * Condition text of a prize.
+ */
+export const StatusCondition = styled.span`
+  font-size: 0.85em;
+  color: ${helperTextColor};
+  margin-left: 0.5em;
+`;
+
+/**
+ * Progress bar of a prize.
+ */
+export const StatusProgressBar = styled.span<{ percent: number }>`
+  display: inline-block;
+  width: 6em;
+  height: 0.8em;
+  margin-left: 0.5em;
+  background-color: ${noColor};
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: ${({ percent }) => `${Math.max(0, Math.min(100, percent))}%`};
+    background-color: ${yesColor};
+  }
+`;
+
+/**
+ * Text of current progress.
+ */
+export const StatusProgressText = styled.span`
+  font-size: 0.85em;
+  min-width: 4em;
+`;
+
+/**
+ * Badge of achieved / not achieved.
+ */
+export const StatusAchievedBadge = styled.span<{ achieved: boolean }>`
+  font-size: 0.85em;
+  font-weight: bold;
+  color: ${({ achieved }) => (achieved ? activeButtonColor : helperTextColor)};
+`;

--- a/front/src/pages/prize/status/index.tsx
+++ b/front/src/pages/prize/status/index.tsx
@@ -1,0 +1,532 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import { bind } from 'bind-decorator';
+import memoizeOne from 'memoize-one';
+import { i18n } from '../../../i18n';
+import { getPrizeStatus } from '../../../api/prize-status';
+import { LinkLikeButton } from '../../../common/button';
+import { PrizeStore } from '..';
+import { PrizeStatusRow, PrizeStatusSeries } from '../defs';
+import {
+  StatusAchievedBadge,
+  StatusCondition,
+  StatusDescription,
+  StatusGroup,
+  StatusGroupSummary,
+  StatusIndent,
+  StatusJobGroup,
+  StatusKindLabel,
+  StatusList,
+  StatusPrizeName,
+  StatusProgressBar,
+  StatusProgressText,
+  StatusRowItem,
+  StatusSection,
+  StatusSeries,
+  StatusSeriesTitle,
+  StatusTitle,
+} from './elements';
+
+/**
+ * Sections of the status display, in display order.
+ * "winlose" is a merged tree of wincount/losecount rows:
+ * team (阵营) -> job (职业) -> win/lose prizes.
+ */
+type StatusSeriesView = 'winlose' | 'winteamcount' | 'counter' | 'ownprizes';
+
+const statusSeriesOrder: StatusSeriesView[] = [
+  'winlose',
+  'winteamcount',
+  'counter',
+  'ownprizes',
+];
+
+/**
+ * Display order of teams for the win/lose tree.
+ * Keys of teams in client/code/shared/game.coffee.
+ */
+const winLoseTeamOrder: string[] = [
+  'Human',
+  'Werewolf',
+  'Fox',
+  'Devil',
+  'Friend',
+  'Vampire',
+  'Cult',
+  'Raven',
+  'Hooligan',
+  'Duel',
+  'Lorelei',
+  'Others',
+  'Neet',
+];
+
+/**
+ * One job node of the win/lose tree.
+ */
+interface WinLoseJobNode {
+  key: string;
+  label: string;
+  win: PrizeStatusRow[];
+  lose: PrizeStatusRow[];
+  achieved: number;
+  total: number;
+}
+
+/**
+ * One team node of the win/lose tree.
+ */
+interface WinLoseTeamNode {
+  key: string;
+  label: string;
+  /**
+   * For the "all" team, rows are attached directly without a job layer.
+   */
+  jobs: WinLoseJobNode[];
+  allWin: PrizeStatusRow[];
+  allLose: PrizeStatusRow[];
+  achieved: number;
+  total: number;
+}
+
+/**
+ * Build the team -> job -> win/lose tree from wincount/losecount rows.
+ */
+function buildWinLoseTree(
+  i18n: i18n,
+  rows: PrizeStatusRow[],
+): WinLoseTeamNode[] {
+  const map = new Map<string, WinLoseTeamNode>();
+  for (const row of rows) {
+    const teamKey = row.team == null ? 'Others' : row.team;
+    let team = map.get(teamKey);
+    if (team == null) {
+      team = {
+        key: teamKey,
+        label:
+          teamKey === 'all' ? i18n.t('status.jobAll') : row.teamName || teamKey,
+        jobs: [],
+        allWin: [],
+        allLose: [],
+        achieved: 0,
+        total: 0,
+      };
+      map.set(teamKey, team);
+    }
+    team.total += 1;
+    if (row.achieved) {
+      team.achieved += 1;
+    }
+    if (teamKey === 'all') {
+      if (row.series === 'wincount') {
+        team.allWin.push(row);
+      } else {
+        team.allLose.push(row);
+      }
+      continue;
+    }
+    let job = team.jobs.find(j => j.key === row.kind);
+    if (job == null) {
+      job = {
+        key: row.kind,
+        label: row.jobName || row.kind,
+        win: [],
+        lose: [],
+        achieved: 0,
+        total: 0,
+      };
+      team.jobs.push(job);
+    }
+    job.total += 1;
+    if (row.achieved) {
+      job.achieved += 1;
+    }
+    if (row.series === 'wincount') {
+      job.win.push(row);
+    } else {
+      job.lose.push(row);
+    }
+  }
+  const byRequired = (a: PrizeStatusRow, b: PrizeStatusRow): number =>
+    a.required - b.required || a.id.localeCompare(b.id);
+  for (const team of map.values()) {
+    team.allWin.sort(byRequired);
+    team.allLose.sort(byRequired);
+    for (const job of team.jobs) {
+      job.win.sort(byRequired);
+      job.lose.sort(byRequired);
+    }
+  }
+  const ordered: WinLoseTeamNode[] = [];
+  const allTeam = map.get('all');
+  if (allTeam != null) {
+    ordered.push(allTeam);
+  }
+  for (const key of winLoseTeamOrder) {
+    const team = map.get(key);
+    if (team != null) {
+      ordered.push(team);
+    }
+  }
+  for (const key of map.keys()) {
+    if (key !== 'all' && winLoseTeamOrder.indexOf(key) < 0) {
+      const team = map.get(key);
+      if (team != null) {
+        ordered.push(team);
+      }
+    }
+  }
+  return ordered;
+}
+
+/**
+ * Build condition text of a prize.
+ */
+function prizeCondition(i18n: i18n, row: PrizeStatusRow): string {
+  // NOTE: i18next types require `count` to be a number.
+  const count = row.required;
+  switch (row.series) {
+    case 'wincount':
+      return row.kind === 'all'
+        ? i18n.t('status.condition.wincountAll', { count })
+        : i18n.t('status.condition.wincount', {
+            job: row.jobName || row.kind,
+            count,
+          });
+    case 'losecount':
+      return row.kind === 'all'
+        ? i18n.t('status.condition.losecountAll', { count })
+        : i18n.t('status.condition.losecount', {
+            job: row.jobName || row.kind,
+            count,
+          });
+    case 'winteamcount':
+      return i18n.t('status.condition.winteamcount', {
+        team: row.teamName || row.kind,
+        count,
+      });
+    case 'counter':
+      return i18n.t('status.condition.counter', {
+        description: i18n.t(`status.counterDescription.${row.kind}`, {
+          defaultValue: row.kind,
+        }),
+        count,
+      });
+    case 'ownprizes':
+      return i18n.t('status.condition.ownprizes', { count });
+  }
+}
+
+/**
+ * Label of a sub-group of a series.
+ */
+function groupLabel(
+  i18n: i18n,
+  series: PrizeStatusSeries,
+  rows: PrizeStatusRow[],
+): string {
+  if (rows.length === 0) {
+    return '';
+  }
+  const row = rows[0];
+  switch (series) {
+    case 'wincount':
+    case 'losecount':
+      return row.kind === 'all'
+        ? i18n.t('status.jobAll')
+        : row.jobName || row.kind;
+    case 'winteamcount':
+      return row.teamName || row.kind;
+    case 'counter':
+      return i18n.t(`status.counterDescription.${row.kind}`, {
+        defaultValue: row.kind,
+      });
+    case 'ownprizes':
+      return '';
+  }
+}
+
+/**
+ * Group rows by kind, sorting each group by required count.
+ */
+function groupRows(rows: PrizeStatusRow[]): PrizeStatusRow[][] {
+  const map = new Map<string, PrizeStatusRow[]>();
+  for (const row of rows) {
+    let group = map.get(row.kind);
+    if (group == null) {
+      group = [];
+      map.set(row.kind, group);
+    }
+    group.push(row);
+  }
+  const result: PrizeStatusRow[][] = [];
+  for (const group of map.values()) {
+    group.sort((a, b) => a.required - b.required || a.id.localeCompare(b.id));
+    result.push(group);
+  }
+  return result;
+}
+
+/**
+ * Display data of one series, computed once per status update.
+ */
+interface PreparedSeries {
+  /**
+   * Rows of the series.
+   */
+  rows: PrizeStatusRow[];
+  /**
+   * Rows grouped by kind, each group sorted by required count.
+   * Undefined for 'winlose' (rendered as a tree) and 'ownprizes'
+   * (no meaningful sub-groups).
+   */
+  groups?: PrizeStatusRow[][];
+}
+
+/**
+ * Display data of all series, keyed like StatusSeriesView.
+ */
+interface PreparedSeriesData {
+  winlose: PreparedSeries;
+  winteamcount: PreparedSeries;
+  counter: PreparedSeries;
+  ownprizes: PreparedSeries;
+}
+
+export interface IPropPrizeStatus {
+  i18n: i18n;
+  store: PrizeStore;
+}
+
+/**
+ * Show prize status (称号图鉴): conditions and progress of all prizes.
+ */
+@observer
+export class PrizeStatus extends React.Component<IPropPrizeStatus, {}> {
+  /**
+   * Memoized preparation of display data of all series.
+   */
+  private prepareData = memoizeOne(
+    (status: PrizeStatusRow[]): PreparedSeriesData => {
+      const winteamcount = status.filter(row => row.series === 'winteamcount');
+      const counter = status.filter(row => row.series === 'counter');
+      return {
+        winlose: {
+          rows: status.filter(
+            row => row.series === 'wincount' || row.series === 'losecount',
+          ),
+        },
+        winteamcount: { rows: winteamcount, groups: groupRows(winteamcount) },
+        counter: { rows: counter, groups: groupRows(counter) },
+        ownprizes: {
+          rows: status.filter(row => row.series === 'ownprizes'),
+        },
+      };
+    },
+  );
+
+  /**
+   * Memoized construction of the win/lose tree.
+   */
+  private winLoseTree = memoizeOne(buildWinLoseTree);
+
+  public render() {
+    const { i18n, store } = this.props;
+    const prepared = this.prepareData(store.status);
+    return (
+      <StatusSection>
+        <StatusTitle>{i18n.t('status.title')}</StatusTitle>
+        <p>
+          <LinkLikeButton onClick={this.handleShrink}>
+            {store.statusShrinked
+              ? i18n.t('status.openLabel')
+              : i18n.t('status.closeLabel')}
+          </LinkLikeButton>
+        </p>
+        {store.statusShrinked ? null : (
+          <>
+            <StatusDescription>
+              {i18n.t('status.description')}
+            </StatusDescription>
+            {statusSeriesOrder.map(series => {
+              const { rows } = prepared[series];
+              if (rows.length === 0) {
+                return null;
+              }
+              const achieved = rows.filter(row => row.achieved).length;
+              return (
+                <StatusSeries key={series}>
+                  <StatusSeriesTitle>
+                    {i18n.t(`status.series.${series}`)}（
+                    {i18n.t('status.groupCount', {
+                      achieved: String(achieved),
+                      total: String(rows.length),
+                    })}
+                    ）
+                  </StatusSeriesTitle>
+                  {this.renderGroups(series, prepared)}
+                </StatusSeries>
+              );
+            })}
+          </>
+        )}
+      </StatusSection>
+    );
+  }
+
+  /**
+   * Render sub-groups of a series.
+   */
+  protected renderGroups(
+    series: StatusSeriesView,
+    prepared: PreparedSeriesData,
+  ): React.ReactNode {
+    const { i18n } = this.props;
+    const { rows, groups } = prepared[series];
+    // ownprizes has no meaningful sub-groups.
+    if (series === 'ownprizes') {
+      return this.renderRows(rows);
+    }
+    // Win/lose counts are rendered as a team -> job -> win/lose tree.
+    if (series === 'winlose') {
+      return this.renderWinLose(rows);
+    }
+    // groups is defined for winteamcount / counter.
+    if (groups == null) {
+      return null;
+    }
+    return (
+      <div>
+        {groups.map(group => {
+          const label = groupLabel(i18n, series, group);
+          const achieved = group.filter(row => row.achieved).length;
+          return (
+            <StatusGroup key={group[0].kind}>
+              <StatusGroupSummary>
+                {label}（
+                {i18n.t('status.groupCount', {
+                  achieved: String(achieved),
+                  total: String(group.length),
+                })}
+                ）
+              </StatusGroupSummary>
+              {this.renderRows(group)}
+            </StatusGroup>
+          );
+        })}
+      </div>
+    );
+  }
+
+  /**
+   * Render the team -> job -> win/lose tree (wincount/losecount rows).
+   */
+  protected renderWinLose(rows: PrizeStatusRow[]): React.ReactNode {
+    const { i18n } = this.props;
+    const teams = this.winLoseTree(i18n, rows);
+    return (
+      <div>
+        {teams.map(team => (
+          <StatusGroup key={team.key}>
+            <StatusGroupSummary>
+              {team.label}（
+              {i18n.t('status.groupCount', {
+                achieved: String(team.achieved),
+                total: String(team.total),
+              })}
+              ）
+            </StatusGroupSummary>
+            {team.key === 'all' ? (
+              <StatusIndent>
+                {this.renderKindSection(team.allWin)}
+                {this.renderKindSection(team.allLose)}
+              </StatusIndent>
+            ) : (
+              team.jobs.map(job => (
+                <StatusJobGroup key={job.key}>
+                  <StatusGroupSummary>
+                    {job.label}（
+                    {i18n.t('status.groupCount', {
+                      achieved: String(job.achieved),
+                      total: String(job.total),
+                    })}
+                    ）
+                  </StatusGroupSummary>
+                  {this.renderKindSection(job.win)}
+                  {this.renderKindSection(job.lose)}
+                </StatusJobGroup>
+              ))
+            )}
+          </StatusGroup>
+        ))}
+      </div>
+    );
+  }
+
+  /**
+   * Render a win / lose subsection inside a job group.
+   */
+  protected renderKindSection(rows: PrizeStatusRow[]): React.ReactNode {
+    const { i18n } = this.props;
+    if (rows.length === 0) {
+      return null;
+    }
+    const title =
+      rows[0].series === 'wincount'
+        ? i18n.t('status.winTitle')
+        : i18n.t('status.loseTitle');
+    return (
+      <div>
+        <StatusKindLabel>{title}</StatusKindLabel>
+        {this.renderRows(rows)}
+      </div>
+    );
+  }
+
+  /**
+   * Render prize status rows.
+   */
+  protected renderRows(rows: PrizeStatusRow[]): React.ReactNode {
+    const { i18n } = this.props;
+    return (
+      <StatusList>
+        {rows.map(row => {
+          const percent =
+            row.required === 0 ? 100 : (row.current / row.required) * 100;
+          return (
+            <StatusRowItem key={row.id}>
+              <StatusPrizeName>{row.name}</StatusPrizeName>
+              <StatusCondition>{prizeCondition(i18n, row)}</StatusCondition>
+              <StatusProgressBar percent={percent} />
+              <StatusProgressText>
+                {i18n.t('status.progress', {
+                  current: String(row.current),
+                  required: String(row.required),
+                })}
+              </StatusProgressText>
+              <StatusAchievedBadge achieved={row.achieved}>
+                {row.achieved
+                  ? i18n.t('status.achieved')
+                  : i18n.t('status.notAchieved')}
+              </StatusAchievedBadge>
+            </StatusRowItem>
+          );
+        })}
+      </StatusList>
+    );
+  }
+
+  @bind
+  protected handleShrink() {
+    const { store } = this.props;
+    if (store.statusShrinked && !store.statusLoaded) {
+      // The status section is expanded first: fetch the progress lazily.
+      getPrizeStatus().then(status => {
+        if (status != null) {
+          store.setStatus(status);
+        }
+      });
+    }
+    store.setStatusShrinked(!store.statusShrinked);
+  }
+}

--- a/front/src/pages/prize/store.ts
+++ b/front/src/pages/prize/store.ts
@@ -5,6 +5,7 @@ import {
   NowPrize,
   NowPrizeType,
   PrizeSelection,
+  PrizeStatus,
 } from './defs';
 import { splitPrizesIntoGroups } from './logic/prize-groups';
 import { fillTemplate } from './logic/fill-nowprize';
@@ -71,6 +72,25 @@ export class PrizeStore {
   public shrinked: boolean = true;
 
   /**
+   * Status of all prizes (conditions and progress).
+   */
+  @observable
+  public status: PrizeStatus = [];
+
+  /**
+   * Whether the status of all prizes is already loaded.
+   * The status is fetched lazily when the section is expanded first.
+   */
+  @observable
+  public statusLoaded: boolean = false;
+
+  /**
+   * Whether the status (称号图鉴) section is shrinked.
+   */
+  @observable
+  public statusShrinked: boolean = true;
+
+  /**
    * Whether a change is made.
    */
   @observable
@@ -82,6 +102,21 @@ export class PrizeStore {
   @action
   public setPrizes(prizes: Prize[]): void {
     this.prizes = prizes;
+  }
+  /**
+   * Set status of all prizes.
+   */
+  @action
+  public setStatus(status: PrizeStatus): void {
+    this.status = status;
+    this.statusLoaded = true;
+  }
+  /**
+   * Set shrinkedness of the prize status section.
+   */
+  @action
+  public setStatusShrinked(shrinked: boolean): void {
+    this.statusShrinked = shrinked;
   }
   /**
    * Set current prizes

--- a/language/ja/prize_client.yaml
+++ b/language/ja/prize_client.yaml
@@ -4,7 +4,7 @@
 title: "称号"
 
 # description of prizes
-description: "称号は勝利回数・敗北回数などの特定を条件を満たすことで入手できます。"
+description: "称号は勝利回数・敗北回数などの特定の条件を満たすことで入手できます。"
 
 # back to mypage link.
 backLink: "マイページに戻る"
@@ -43,3 +43,56 @@ save:
   # reminder to save
   reminder: "変更を反映するには「肩書きを保存」ボタンを押してください。"
 
+# prize status (称号図鑑)
+status:
+  # title of the status section
+  title: "称号図鑑（獲得条件と進捗）"
+  # label of open button of the status section
+  openLabel: "称号の条件と進捗を見る"
+  # label of close button of the status section
+  closeLabel: "称号図鑑を閉じる"
+  # description of the status section
+  description: "ここでは、獲得できる全ての称号の達成条件と現在の進捗を表示します。勝敗回数称号は「陣営 → 職業 → 勝利/敗北」の階層でグループ化され、特殊称号は種類ごとにグループ化されています。各階層の分類をクリックすると展開して確認できます。"
+  # titles of series
+  series:
+    winlose: "勝敗回数称号"
+    winteamcount: "陣営勝利称号"
+    counter: "特殊称号（回数）"
+    ownprizes: "称号収集数"
+  # labels of win / lose subsections inside a job group
+  winTitle: "勝利称号"
+  loseTitle: "敗北称号"
+  # label of the group of "all jobs"
+  jobAll: "全職業"
+  # achieved / not achieved
+  achieved: "獲得済み"
+  notAchieved: "未獲得"
+  # progress text
+  progress: "{{current}}/{{required}}"
+  # count summary of a series or a group
+  groupCount: "獲得済み {{achieved}}/{{total}}"
+  # condition texts
+  condition:
+    wincount: "「{{job}}」で勝利 {{count}}回"
+    wincountAll: "勝利 {{count}}回（全職業合計）"
+    losecount: "「{{job}}」で敗北 {{count}}回"
+    losecountAll: "敗北 {{count}}回（全職業合計）"
+    winteamcount: "陣営「{{team}}」で勝利 {{count}}回"
+    counter: "{{description}} {{count}}回"
+    ownprizes: "称号を {{count}}個獲得"
+  # descriptions of counter prizes
+  counterDescription:
+    cursekill: "相手を呪殺する"
+    divineblack2: "1日目の夜の占いで人狼と出る（初日黒）"
+    GJ: "護衛に成功する（GJ判定を獲得）"
+    lovers_wincount: "恋人として勝利する"
+    lovers_losecount: "恋人として敗北する"
+    getkits_merchant: "商品を受け取る"
+    sendkits_to_wolves: "商品を人狼側に送る"
+    nocopy: "コピーせずに終了"
+    day2hanged: "2日目の昼に吊られる"
+    allgamecount: "ゲームに参加する"
+    aliveatlast: "ゲーム終了時に生存"
+    revive: "蘇生する"
+    brainwashed: "洗脳されて信者になる"
+    shishimaibit: "獅子舞に噛まれる"

--- a/server/prize.coffee
+++ b/server/prize.coffee
@@ -9,6 +9,61 @@ prizedata.makePrize (r)->
 
     # console.log prize
 
+# 称号の静的定義から決まる部分(ID・達成条件・名称など)のスケルトン。
+# 定義は実行中に変わらないので、初回の1回だけ構築して再利用する。
+# 各行: {id,series,kind,team,required,name,phonetic}
+#   series: "wincount" | "losecount" | "winteamcount" | "counter" | "ownprizes"
+#   kind:   系列内の分類キー(職業名 / 陣営名 / カウント称号名)
+#   team:   職業の所属陣営キー(wincount/losecount のみ。"all"=全職業通算、他系列はnull)
+prizeStatusSkeleton=null
+makePrizeStatusSkeleton=->
+    unless prize.winteamcountprize?
+        # 定義の読み込みがまだ済んでいない
+        return null
+    rows=[]
+    # 一つの称号枠からスケルトン行を生成する(複数名称の称号は複数行になる)
+    pushRows=(series,kind,idbase,countstr,raw,teamkey)->
+        required=+countstr
+        raws=if Array.isArray raw then raw else [raw]
+        for name,i in raws
+            [dname,dphonetic]=name.split "/"
+            rows.push
+                id: if i==0 then idbase else "#{idbase}:#{i}"
+                series: series
+                kind: kind
+                team: teamkey ? null
+                required: required
+                name: dname
+                phonetic: if dphonetic? then dphonetic else ""
+    # 勝利回数
+    if prize.wincountprize?
+        for job,obj of prize.wincountprize
+            # special_for_zhinai は特別貢献で手動付与される称号なので一覧には含めない
+            continue if job=="special_for_zhinai"
+            teamkey=if job=="all" then "all" else (prizedata.getTeamByType(job) || "Others")
+            for countstr,name of obj
+                pushRows "wincount",job,"wincount_#{job}_#{countstr}",countstr,name,teamkey
+    # 敗北回数
+    if prize.losecountprize?
+        for job,obj of prize.losecountprize
+            continue if job=="special_for_zhinai"
+            teamkey=if job=="all" then "all" else (prizedata.getTeamByType(job) || "Others")
+            for countstr,name of obj
+                pushRows "losecount",job,"losecount_#{job}_#{countstr}",countstr,name,teamkey
+    # 陣営勝利回数
+    for team,obj of prize.winteamcountprize
+        for countstr,name of obj
+            pushRows "winteamcount",team,"winteamcount_#{team}_#{countstr}",countstr,name,null
+    # カウント系
+    for type,obj of prize.counterprize
+        for countstr,name of obj.names
+            pushRows "counter",type,"#{type}_#{countstr}",countstr,name,null
+    # 所持数
+    for type,obj of prize.ownprizesprize
+        for countstr,name of obj.names
+            pushRows "ownprizes",type,"#{type}_#{countstr}",countstr,name,null
+    rows
+
 # 内部用
 module.exports=exports=
     checkPrize:(game,cb)->
@@ -194,7 +249,40 @@ module.exports=exports=
     prizeName:(prizeid)->prize.names[prizeid]    # IDを名前に
     prizePhonetic:(prizeid)->prize.phonetics[prizeid]
     prizeQuote:(prizename)->"≪#{prizename}≫"
-            
+
+    # 称号の状態一覧(達成条件と現在の進捗)を計算する
+    # 引数の userlog は userlogs コレクションのドキュメント
+    # 戻り値: [{id,series,kind,team,required,current,achieved,name,phonetic}, ...]
+    # 静的部分はスケルトンを再利用し、進捗(current/achieved)だけを毎回埋める
+    getPrizeStatus:(userlog)->
+        prizeStatusSkeleton ?= makePrizeStatusSkeleton()
+        unless prizeStatusSkeleton?
+            # 定義の読み込みがまだ済んでいない
+            return []
+        wincount=userlog?.wincount ? {}
+        losecount=userlog?.losecount ? {}
+        winteamcount=userlog?.winteamcount ? {}
+        counter=userlog?.counter ? {}
+        result=[]
+        # ownprizes系以外で達成済みの称号数(ownprizes系の判定に使う)
+        achievedcount=0
+        # ownprizes系は一覧の最後に来るので、そこまでの達成数で判定できる
+        for row in prizeStatusSkeleton
+            current=switch row.series
+                when "wincount" then wincount[row.kind] ? 0
+                when "losecount" then losecount[row.kind] ? 0
+                when "winteamcount" then winteamcount[row.kind] ? 0
+                when "counter" then counter[row.kind] ? 0
+                else achievedcount
+            achieved=current>=row.required
+            # 毎回新しい行にする(rpc層がjobName等を後付けするため)
+            result.push Object.assign {}, row,
+                current: current
+                achieved: achieved
+            if achieved && row.series!="ownprizes"
+                achievedcount+=1
+        result
+
 ###
 ・役職ごとの勝利回数賞
 "wincount_(役職名)_(回数)" というIDをつける

--- a/server/rpc/user.coffee
+++ b/server/rpc/user.coffee
@@ -224,6 +224,39 @@ exports.actions =(req,res,ss)->
             prizes: generatePrizeDataForClient req.session.user.prize
             nowprize: req.session.user.nowprize
         }
+    # 称号の状態一覧（条件と進捗）を取得
+    getPrizeStatus: ->
+        unless req.session.userId
+            # not logged in
+            res {
+                error: i18n.t "common:error.needLogin"
+            }
+            return
+        # 計算に必要なカウンタだけ取得する(projection)
+        M.userlogs.findOne {userid:req.session.userId}, {
+            fields: {
+                wincount: true
+                losecount: true
+                winteamcount: true
+                counter: true
+            }
+        },(err,doc)->
+            if err?
+                console.error err
+                res {error: i18n.t "common:error.error"}
+                return
+            statuses = Server.prize.getPrizeStatus(doc)
+            # 職業名・陣営名を補完する
+            for row in statuses
+                switch row.series
+                    when "wincount","losecount"
+                        row.jobName = if row.kind=="all" then null else i18n.t "roles:jobname.#{row.kind}"
+                        row.teamName = if row.team=="all" then null else i18n.t "roles:teamName.#{row.team}"
+                    when "winteamcount"
+                        row.teamName = i18n.t "roles:teamName.#{row.kind}"
+            res {
+                statuses: statuses
+            }
 # お知らせをとってきてもらう
     getNews:->
         M.news.find().sort({time:-1}).limit(5).toArray (err,results)->


### PR DESCRIPTION
Add a new PrizeStatus section to the prize page that displays each prize's condition and current progress for the logged-in user.

- Add getPrizeStatus API (front/src/api/prize-status.ts) that fetches prize statuses via the legacy ss rpc (user.getPrizeStatus) and resolves null on failure
- Define PrizeStatus, PrizeStatusRow and PrizeStatusSeries types in pages/prize/defs.ts
- Render a grouped status list (team/job groups for win/lose counts, counter groups, etc.) with achieved/total summaries and progress under the existing prize list